### PR TITLE
chore(flake/nixpkgs): `e49cd51e` -> `b47203b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1635587056,
-        "narHash": "sha256-2RzriuQ8OEvY+wRUTpCgIiNNuFukKa7CiEAA0b2gsew=",
+        "lastModified": 1642238013,
+        "narHash": "sha256-MMW3dkmhj6UwtzhgSjmrlaZVqaGXaU1DpIIi65LMCg0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e49cd51ebcbb916e2481555aad8d9548807e9d12",
+        "rev": "b47203b28f5cf1efc4e3476ca8f333db3a2c3223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`ab58c31e`](https://github.com/NixOS/nixpkgs/commit/ab58c31ecb3ebf597f63e30ce34e80f3da87c0e0) | `pythonPackages.timetagger: 21.11.2 -> 22.1.2`                                                                     |
| [`65aaf4e2`](https://github.com/NixOS/nixpkgs/commit/65aaf4e22dcf77a7559b4745f1e301059f9dff82) | `Add timetagger to release notes`                                                                                  |
| [`1f10b043`](https://github.com/NixOS/nixpkgs/commit/1f10b0434f96c8fc7b68ab32f245159e6dbc83fb) | `timetagger: Make enable option with mkOption`                                                                     |
| [`b90efe70`](https://github.com/NixOS/nixpkgs/commit/b90efe70883d5de9ccd4aa99f56f83b483fe4b97) | `pythonPackages.pscript: Add test inputs`                                                                          |
| [`6304e619`](https://github.com/NixOS/nixpkgs/commit/6304e619bca38074a1933a62993a87dee1df226f) | `pythonPackages.timetagger: Add test inputs`                                                                       |
| [`87419823`](https://github.com/NixOS/nixpkgs/commit/87419823ada3f19b0c5fc5cac26614b8c48417ac) | `pythonPackages.asgineer: Add test inputs`                                                                         |
| [`a24dc8d2`](https://github.com/NixOS/nixpkgs/commit/a24dc8d2ef61ccbd16f2a046c83be2e5ab2bdd9a) | `timetagger: Use default value for package option`                                                                 |
| [`f3eaf668`](https://github.com/NixOS/nixpkgs/commit/f3eaf668820a41ec78a6b6d8aedb078b4a87372e) | `Add service module for timetagger`                                                                                |
| [`a2a43df9`](https://github.com/NixOS/nixpkgs/commit/a2a43df955355e4679acc04dc71a7c737950dd60) | `timetagger: init at 21.11.2`                                                                                      |
| [`e9d1e53c`](https://github.com/NixOS/nixpkgs/commit/e9d1e53c6ebbfe512d3fd8ea76a428eb7cf3a2e5) | `pythonPackages.asgineer: init at 0.8.1`                                                                           |
| [`4f44ede4`](https://github.com/NixOS/nixpkgs/commit/4f44ede48e9e8b8c2849f247f514d61e11149649) | `pythonPackages.itemdb: init at 1.1.1`                                                                             |
| [`84ca2001`](https://github.com/NixOS/nixpkgs/commit/84ca20017bb8e36e11ebdf9ae9939230ba531fd9) | `pythonPackages.pscript: init at 0.7.6`                                                                            |
| [`079205c6`](https://github.com/NixOS/nixpkgs/commit/079205c6f9a7d9f82e18ab0ac062dd714cd5403e) | `maintainers: add derekcollison`                                                                                   |
| [`3b151fce`](https://github.com/NixOS/nixpkgs/commit/3b151fcec87a19f7d3e197d17c6ad43843b02073) | `hidrd: mark as broken on darwin`                                                                                  |
| [`bb08b954`](https://github.com/NixOS/nixpkgs/commit/bb08b95456ae497f1bd594889328867debc0f270) | `gthree: mark as broken on darwin`                                                                                 |
| [`a3720ac9`](https://github.com/NixOS/nixpkgs/commit/a3720ac9a1b5625f8f39fb50d61f13e627390576) | `xiphos: clean up dependencies`                                                                                    |
| [`7cf24465`](https://github.com/NixOS/nixpkgs/commit/7cf24465b2e971b2e7ea797a9654ad0205213765) | `xiphos: drop lucene`                                                                                              |
| [`569eea8e`](https://github.com/NixOS/nixpkgs/commit/569eea8ec1ea42a83dda23fe00bc6c0d080bc93f) | `xiphos: do not use patchFlags`                                                                                    |
| [`94517ee0`](https://github.com/NixOS/nixpkgs/commit/94517ee0c77aebad0278a5e8888b86b66f8dad59) | `gnome2.gtkhtml4: do not use patchFlags`                                                                           |
| [`fe1ba3c9`](https://github.com/NixOS/nixpkgs/commit/fe1ba3c9be690ce82e3f008912cc6a50bb2cc4b3) | `xiphos: clean up the expression`                                                                                  |
| [`2efc9721`](https://github.com/NixOS/nixpkgs/commit/2efc97211316560936d8b69f6c5ce8e7af74ff8e) | `wluma: 2.0.1 -> 3.0.0 (#155059)`                                                                                  |
| [`08157484`](https://github.com/NixOS/nixpkgs/commit/081574842a69cecc73ca6c134eb6f02b5aaf64ed) | `wrangler: 1.19.6 -> 1.19.7 (#154459)`                                                                             |
| [`31b1d005`](https://github.com/NixOS/nixpkgs/commit/31b1d00569111ee2e0649337b0c2f0f028352099) | `esbuild: 0.14.8 -> 0.14.11 (#154463)`                                                                             |
| [`f51b5782`](https://github.com/NixOS/nixpkgs/commit/f51b5782da82f3f1085fa2a473232ee3fe6e6953) | `heisenbridge: 1.8.2 -> 1.10.0`                                                                                    |
| [`8a6cde91`](https://github.com/NixOS/nixpkgs/commit/8a6cde9143085d40886de34037c913323984e7f4) | `discord: add derivations for {x86_64,aarch64}-darwin`                                                             |
| [`ae1bee34`](https://github.com/NixOS/nixpkgs/commit/ae1bee344a09129db2c13d5564e632934b68cdaf) | `blightmud: init at 3.5.0`                                                                                         |
| [`36026bb0`](https://github.com/NixOS/nixpkgs/commit/36026bb0c4da767610f2a8eceaa1123e1b1cb2ae) | `linuxPackages.kvmfr: patch for 5.16`                                                                              |
| [`c45b63bc`](https://github.com/NixOS/nixpkgs/commit/c45b63bcbfe364cc0d1c80321a55fae45125d0fe) | `exploitdb: 2022-01-11 -> 2022-01-14`                                                                              |
| [`4369bebd`](https://github.com/NixOS/nixpkgs/commit/4369bebd9a32658ded22b580886587cdc577a29d) | `nixos/tests: remove broken prosody-mysql test`                                                                    |
| [`8b8fbbf1`](https://github.com/NixOS/nixpkgs/commit/8b8fbbf1fa5d8da120e89a279b646bf16760d30a) | `prosody:  0.11.10 -> 0.11.12`                                                                                     |
| [`97a8c722`](https://github.com/NixOS/nixpkgs/commit/97a8c7228abcbf1696554dc930f05666d5cd522e) | `linuxPackages.nvidia_x11_beta: 495.29.05 -> 510.39.01`                                                            |
| [`4e7e160e`](https://github.com/NixOS/nixpkgs/commit/4e7e160ea6a44e7d1731e11399a5bdd6a6bd505b) | `olm: 3.2.8 -> 3.2.9`                                                                                              |
| [`e6acb6f5`](https://github.com/NixOS/nixpkgs/commit/e6acb6f5cb8b4dd89dde94151fc9a695cb1d78d1) | `python3Packages.logfury: adjust inputs`                                                                           |
| [`f86eb879`](https://github.com/NixOS/nixpkgs/commit/f86eb879a0adb7425e48e910e3e212946224224a) | `python3Packages.scrapy: disable failing test`                                                                     |
| [`b6a83b48`](https://github.com/NixOS/nixpkgs/commit/b6a83b4867b909adc50b4da5dc239763b0795f2c) | `mautrix-signal: 2021-11-12 -> 2022-01-14`                                                                         |
| [`e040f9cd`](https://github.com/NixOS/nixpkgs/commit/e040f9cd641d41f32abdccf8c706aec6a2379c50) | `mautrix: 0.14.3 -> 0.14.4`                                                                                        |
| [`b24a2be2`](https://github.com/NixOS/nixpkgs/commit/b24a2be269d0780a4627e955b4abf9fd254dadbc) | `deadnix: init at 0.1.3`                                                                                           |
| [`47a8b156`](https://github.com/NixOS/nixpkgs/commit/47a8b15664f45dc66c166be35e0615163b6199d3) | `evolution-data-server: propagate libgdata`                                                                        |
| [`ffde221d`](https://github.com/NixOS/nixpkgs/commit/ffde221dcb839fc4febdf8106ae5e896383ebaf4) | `python3Packages.pytorch-bin: enable on darwin (cpu build)`                                                        |
| [`8a552994`](https://github.com/NixOS/nixpkgs/commit/8a552994d8e91b206b7d807917d1bbca54ce1145) | `nixos/build-vm.nix: Fix docs eval`                                                                                |
| [`43d5b318`](https://github.com/NixOS/nixpkgs/commit/43d5b318d80322bd460edee2e054f3d5f5db027e) | `python3Packages.ytmusicapi: 0.19.5 -> 0.20.0`                                                                     |
| [`a40f3bc8`](https://github.com/NixOS/nixpkgs/commit/a40f3bc88e10dbe9abdb1a5553a0cd7f0c41682a) | `python3Packages.pyturbojpeg: 1.6.3 -> 1.6.4`                                                                      |
| [`c52d6cf4`](https://github.com/NixOS/nixpkgs/commit/c52d6cf465394106940801292762aa70c6f0fa6c) | `python3Packages.repeated_test: remove`                                                                            |
| [`97003d11`](https://github.com/NixOS/nixpkgs/commit/97003d11f001ca0c2bc5f5ac9540aee8e28ff386) | `python310Packages.bibtexparser: 1.1.0 -> 1.2.0`                                                                   |
| [`50ede5f4`](https://github.com/NixOS/nixpkgs/commit/50ede5f4e0997259e1f170342e185b9f8929e181) | `clamav: 0.103.3 -> 0.103.5`                                                                                       |
| [`379ab505`](https://github.com/NixOS/nixpkgs/commit/379ab505d0b42238208fa87ae32d630b88bef98e) | `python310Packages.batchgenerators: remove unittest2`                                                              |
| [`d67829cf`](https://github.com/NixOS/nixpkgs/commit/d67829cf88d5f58598199ab3f61a78329c0247a7) | `ocamlPackages.fix: 20201120 -> 20211231`                                                                          |
| [`c1336ddd`](https://github.com/NixOS/nixpkgs/commit/c1336ddd8c809ca2da4e4e79c6f9614c99688636) | `wireplumber: backport default device selection fix from master`                                                   |
| [`e09b9d40`](https://github.com/NixOS/nixpkgs/commit/e09b9d401fe58a3f2bac3b93830a82ec4d8f8b01) | `hyper: 3.1.4 -> 3.1.5`                                                                                            |
| [`c9fa779a`](https://github.com/NixOS/nixpkgs/commit/c9fa779ad7b9c396ccae65a90cf43746d5047c84) | `khronos-ocl-icd-loader: 2021.06.30 -> 2022.01.04`                                                                 |
| [`e956c766`](https://github.com/NixOS/nixpkgs/commit/e956c766327c95bf39a5a09f8c9c62d10d595ead) | `python3Packages.tifffile: refactor`                                                                               |
| [`162d4c51`](https://github.com/NixOS/nixpkgs/commit/162d4c51b3e193bf78beb584b172462a68adb66b) | `ryzenadj: 0.8.2 -> 0.8.3`                                                                                         |
| [`70126f0e`](https://github.com/NixOS/nixpkgs/commit/70126f0e4ac7b4df2becc34696e35a8e38837b55) | `ocamlPackages.progress: 0.1.1 → 0.2.1`                                                                            |
| [`94aeee3a`](https://github.com/NixOS/nixpkgs/commit/94aeee3af18511fed2712ba64b065bd554a8d0a7) | `ocamlPackages.vector: init at 1.0.0`                                                                              |
| [`55eac498`](https://github.com/NixOS/nixpkgs/commit/55eac498436b38fe8630dea089cdd861e191130b) | `ocamlPackages.terminal: init at 0.2.1`                                                                            |
| [`7b71c6e7`](https://github.com/NixOS/nixpkgs/commit/7b71c6e756f0cb8fd56ebca0646bb786b535f7f0) | `python3Packages.roombapy: replace hbmqtt with amqtt`                                                              |
| [`827da032`](https://github.com/NixOS/nixpkgs/commit/827da032023260cb3ff28f9f4bf1ad205c68f365) | `glitter: 1.5.11 -> 1.5.12`                                                                                        |
| [`2bf50427`](https://github.com/NixOS/nixpkgs/commit/2bf5042700a2c085c0b13dba22015a7fe3fda224) | `python3Packages.amqtt: 0.10.0 -> unstable-2022-01-11`                                                             |
| [`5eb7d1ed`](https://github.com/NixOS/nixpkgs/commit/5eb7d1ed25f83c591d4764b345b337bd5422cb6d) | `python3Packages.pytest-logdog: init at 0.1.0`                                                                     |
| [`2a0c0881`](https://github.com/NixOS/nixpkgs/commit/2a0c0881c2e9df1b4667f86fa7cc43b061722845) | `ferdi: 5.6.5 -> 5.7.0`                                                                                            |
| [`35f8dc6e`](https://github.com/NixOS/nixpkgs/commit/35f8dc6ecc69a90dfa9287088fd49c7c2cb3e9a3) | `yaml-merge: unstable-2016-02-16 -> unstable-2022-01-12`                                                           |
| [`98ba0568`](https://github.com/NixOS/nixpkgs/commit/98ba056822f3a1c846daec2080267bfa73e3869f) | `python310Packages.sqlalchemy-migrate: fix build by removing unittest2, adopt into openstack team, minor cleanups` |
| [`2b7f7b4b`](https://github.com/NixOS/nixpkgs/commit/2b7f7b4b66a435df6651c619ca893a167a207854) | `python3Packages.transitions: disable failing tests`                                                               |
| [`57309193`](https://github.com/NixOS/nixpkgs/commit/573091938b584a99927e413dced7f48a369774b0) | `crun: 1.4 -> 1.4.1`                                                                                               |
| [`e5a50e8f`](https://github.com/NixOS/nixpkgs/commit/e5a50e8f2995ff359a170d52cc40adbcfdd92ba4) | `gitlab: 14.6.1 -> 14.6.2 (#154997)`                                                                               |
| [`8cb070da`](https://github.com/NixOS/nixpkgs/commit/8cb070da131c2adc102bec2db2470292647e1fe9) | `dura: init at 0.1.0`                                                                                              |
| [`7ce72f00`](https://github.com/NixOS/nixpkgs/commit/7ce72f00e69cfb4a0727889f6775c2c78bb9ef4b) | `python3Packages.wavedrom: minor adjustments`                                                                      |
| [`c1d77e4d`](https://github.com/NixOS/nixpkgs/commit/c1d77e4dd1c05cfd7efe6b0ecff001514e48c867) | `colima: 0.2.2 -> 0.3.1`                                                                                           |
| [`526276aa`](https://github.com/NixOS/nixpkgs/commit/526276aa9b3b8d4ae3b9f5f2ae872a6295f0e5ff) | `python3Packages.attrdict: refactor for Python 3.10`                                                               |
| [`f5914d93`](https://github.com/NixOS/nixpkgs/commit/f5914d93477172e80cabfc87fb758e7012572f91) | `python.pkgs.roboschool: remove`                                                                                   |
| [`3fc8be27`](https://github.com/NixOS/nixpkgs/commit/3fc8be277da9ef16fded052863df1d336176ca54) | `sqlcipher: grab CFLAGS from sqlite`                                                                               |
| [`d1787b02`](https://github.com/NixOS/nixpkgs/commit/d1787b020f4a94add60a7bb07072766b17464183) | `vyper: remove unused postPatch and add setuptools-scm`                                                            |
| [`85c0199c`](https://github.com/NixOS/nixpkgs/commit/85c0199ce6c288141cf3c98d7b2673ce370db866) | `python3Packages.can: 3.3.4 -> unstable-2022-01-11`                                                                |
| [`d14c5678`](https://github.com/NixOS/nixpkgs/commit/d14c5678306b71393619796c70d50ca07eb257cb) | `luna-icons: 1.8 -> 1.9`                                                                                           |
| [`3a8627dc`](https://github.com/NixOS/nixpkgs/commit/3a8627dcf796b8dfd41d3e4886dff7683fc9f21f) | `python3Packages.cart: adjust inputs`                                                                              |
| [`387f3616`](https://github.com/NixOS/nixpkgs/commit/387f36163830ba937e0b425ba091b3b98fda30f4) | `python3Packages.flux-led: 0.28.2 -> 0.28.3`                                                                       |
| [`2bb53292`](https://github.com/NixOS/nixpkgs/commit/2bb53292610b10f27db73db588f2120abc4d6cf9) | `python3Packages.flux-led: 0.28.1 -> 0.28.2`                                                                       |
| [`6390150a`](https://github.com/NixOS/nixpkgs/commit/6390150a0562aef42e7197760c98fc668cac0d7c) | `python3Packages.connexion: relax pyyaml and jsonschema constraint`                                                |
| [`2b9f8eb0`](https://github.com/NixOS/nixpkgs/commit/2b9f8eb0a27df820dc2ab77231e9c816cc95ad41) | `graphia: mark as broken on darwin`                                                                                |
| [`69d78f17`](https://github.com/NixOS/nixpkgs/commit/69d78f174a80db9edc542dd8a384a8d6941ed66e) | `gplates: mark as broken on darwin`                                                                                |
| [`4eae92ee`](https://github.com/NixOS/nixpkgs/commit/4eae92eea2aa27055c6f85c7eaf5fca41bcd4315) | `go365: fix for darwin`                                                                                            |
| [`656e878a`](https://github.com/NixOS/nixpkgs/commit/656e878a109682c147ef1a3c101e33cc47fd38e1) | `lima: 0.8.0 -> 0.8.1`                                                                                             |
| [`cc5ffb3d`](https://github.com/NixOS/nixpkgs/commit/cc5ffb3de43f93be6e065963a93a34f294c01022) | `root: Explicit specify -Dtmva=ON`                                                                                 |
| [`336cc50b`](https://github.com/NixOS/nixpkgs/commit/336cc50b1ffd8b6be32d2f85496686944cc66ab7) | `root: add openblas and lapack into buildInputs for TMVA`                                                          |
| [`fca7543b`](https://github.com/NixOS/nixpkgs/commit/fca7543bd13bb4b248072c8bf5ebda6befe316e6) | `telescope: 0.6.1 → 0.7`                                                                                           |
| [`ff372d0e`](https://github.com/NixOS/nixpkgs/commit/ff372d0ef113d714249c34a6bc53cb89d6635afe) | `spice-up: 1.8.2 -> 1.9.1`                                                                                         |
| [`84d39618`](https://github.com/NixOS/nixpkgs/commit/84d39618cb41f6c2b3842aa173454c9983b6b2d4) | `zxing-cpp: 1.1.1 -> 1.2.0`                                                                                        |
| [`d8527685`](https://github.com/NixOS/nixpkgs/commit/d852768538d8e36117a7c367f5625296b08200fd) | `tinycc: unstable-2021-10-09 -> 0.9.27+date=2022-01-11`                                                            |
| [`b316efff`](https://github.com/NixOS/nixpkgs/commit/b316efff4b10d79d49f8e8fe63bbc93fbedefe9f) | `update-python-libraries: skip replacing 'rev' when set to variable`                                               |
| [`ce0a9077`](https://github.com/NixOS/nixpkgs/commit/ce0a90773077a52e2ce7fd6094078b075dd76867) | `update-python-libraries: support pyproject and flit formats`                                                      |
| [`d016f26c`](https://github.com/NixOS/nixpkgs/commit/d016f26cda25afbc0718a5fef173b4e1de4d4eaa) | `python3Packages.weasyprint: disabled overly sensitive tab tests`                                                  |
| [`bf0f2327`](https://github.com/NixOS/nixpkgs/commit/bf0f23274136ddb2b6b0fa91952e1453b990a88d) | `python3Packages.uamqp: 1.4.3 -> 1.5.1`                                                                            |
| [`0dc088f8`](https://github.com/NixOS/nixpkgs/commit/0dc088f8fb8a434269c59a1b1feafeea10cf868b) | `azure-cli: 2.30.0 -> 2.32.0`                                                                                      |
| [`b9f67c80`](https://github.com/NixOS/nixpkgs/commit/b9f67c80b93d8cfb784d51ba948a01d3fb1c0fae) | `python3Packages.humanfriendly: 9.2 -> 10.0`                                                                       |
| [`28caec18`](https://github.com/NixOS/nixpkgs/commit/28caec1863c257403d4456c2d6a8b24f9c61c653) | `python3Packages.msal-extensions: 0.3.0 -> 0.3.1`                                                                  |
| [`ca58830d`](https://github.com/NixOS/nixpkgs/commit/ca58830d5bddc425f5ff97cea04de5f603948c04) | `python3Packages.azure-synapse-artifacts: 0.10.0 -> 0.11.0`                                                        |
| [`3ff5aff3`](https://github.com/NixOS/nixpkgs/commit/3ff5aff30fe253a5a31b90a7294f5c6497c0df6f) | `python3Packages.azure-servicefabric: 8.0.0.0 -> 8.2.0.0`                                                          |
| [`c64cbc43`](https://github.com/NixOS/nixpkgs/commit/c64cbc43e32af56db372011a796923517d040926) | `python3Packages.azure-servicebus: 7.4.0 -> 7.5.0`                                                                 |
| [`7e41403f`](https://github.com/NixOS/nixpkgs/commit/7e41403fb41d224a56a5e4b23011eee45dec96cd) | `python3Packages.azure-mgmt-web: 5.0.0 -> 6.0.0`                                                                   |
| [`6292946a`](https://github.com/NixOS/nixpkgs/commit/6292946a6881bf9739d7a9a253b5567744ea65f7) | `python3Packages.azure-mgmt-netapp: 5.1.0 -> 6.0.1`                                                                |
| [`7a254a7f`](https://github.com/NixOS/nixpkgs/commit/7a254a7fc8d0c089e5c95725d444c1724efb66b9) | `python3Packages.azure-mgmt-imagebuilder: 0.4.0 -> 1.0.0`                                                          |
| [`a0165628`](https://github.com/NixOS/nixpkgs/commit/a0165628912888aa63958c9a52bc20676704b199) | `python3Packages.azure-mgmt-eventgrid: 10.0.0 -> 10.1.0`                                                           |
| [`c2adb775`](https://github.com/NixOS/nixpkgs/commit/c2adb775da3a7ae4366ff2887583f4c1d19c2593) | `python3Packages.azure-mgmt-datafactory: 2.1.0 -> 2.2.0`                                                           |
| [`42774808`](https://github.com/NixOS/nixpkgs/commit/4277480825c95b132ef55cc9ff34ebd37b458f4b) | `python3Packages.azure-mgmt-applicationinsights: 1.0.0 -> 2.0.0`                                                   |
| [`ec31075e`](https://github.com/NixOS/nixpkgs/commit/ec31075eaefa30e3da5eb100e5ea73580136fa4c) | `python3Packages.azure-mgmt-apimanagement: 2.1.0 -> 3.0.0`                                                         |
| [`a7d7bebd`](https://github.com/NixOS/nixpkgs/commit/a7d7bebd0d52520c7306250c2311be2307874023) | `python3Packages.azure-eventhub: 5.6.1 -> 5.7.0`                                                                   |
| [`b409d14e`](https://github.com/NixOS/nixpkgs/commit/b409d14ef1fde3625f74539d14b55672ae4bd268) | `electron_16: 16.0.6 -> 16.0.7`                                                                                    |
| [`459949f7`](https://github.com/NixOS/nixpkgs/commit/459949f7a18e34b4771b5792e40dab10909290e7) | `electron_15: 15.3.4 -> 15.3.5`                                                                                    |
| [`dc0e1436`](https://github.com/NixOS/nixpkgs/commit/dc0e14368abd408996155274274d7b36ba58eb94) | `electron_14: 14.2.3 -> 14.2.4`                                                                                    |
| [`1e540bba`](https://github.com/NixOS/nixpkgs/commit/1e540bba5a6ed8e26eabe20913397be1d07ff8dd) | `electron_13: 13.6.6 -> 13.6.7`                                                                                    |
| [`a5d4af40`](https://github.com/NixOS/nixpkgs/commit/a5d4af4024750c773cb50f3f7289834d8ed128f1) | `python3Packages.wandb: 0.12.7 -> 0.12.9 (#154800)`                                                                |
| [`1d817316`](https://github.com/NixOS/nixpkgs/commit/1d817316423c385b027f9a46455ca2c1c4fc1423) | `kicad: 6.0.0 -> 6.0.1`                                                                                            |
| [`d98b76cf`](https://github.com/NixOS/nixpkgs/commit/d98b76cf5b29a4348ef7924bed12609c98dcab59) | `kicad-unstable: 2021-12-23 -> 2022-01-13`                                                                         |
| [`1ea35d50`](https://github.com/NixOS/nixpkgs/commit/1ea35d50d84aa6e85a99a4ed593df7ed629b3974) | `python3Packages.pygal: 2.4.0 -> 3.0.0`                                                                            |
| [`615520b1`](https://github.com/NixOS/nixpkgs/commit/615520b1785d6988505e9f9ede34a3c0d6f19d30) | `python3Packages.meshtastic: 1.2.53 -> 1.2.54`                                                                     |
| [`2d377340`](https://github.com/NixOS/nixpkgs/commit/2d377340cafb32c709a406fc61530362a8cbf74e) | `python310Packages.cssutils: fix tests`                                                                            |
| [`285a0f70`](https://github.com/NixOS/nixpkgs/commit/285a0f7042fcdbfa14a5151970f553250c537be0) | `python3Packages.restview: 2.9.3 -> 3.0.0`                                                                         |
| [`2b7f3690`](https://github.com/NixOS/nixpkgs/commit/2b7f36902600d22d11ddffe39f2e701e77552ea4) | `grafana-loki: 2.4.1 -> 2.4.2 (#154835)`                                                                           |
| [`8c306506`](https://github.com/NixOS/nixpkgs/commit/8c30650658e26faba9dee6e46caf5e387ba22286) | `home-assistant: add new overrides`                                                                                |
| [`c812713c`](https://github.com/NixOS/nixpkgs/commit/c812713c102dd1645c421fc434b944b9a5a76e6d) | `dablin: 1.13.0 -> 1.14.0`                                                                                         |
| [`40c7f692`](https://github.com/NixOS/nixpkgs/commit/40c7f692a461d79ed177d8d2dd22c463a326526c) | `maigret: 0.3.1 -> 0.4.0`                                                                                          |
| [`d79b4037`](https://github.com/NixOS/nixpkgs/commit/d79b4037a352909445925a386be51b8e5548d712) | `python3Packages.testfixtures: disable failing tests`                                                              |
| [`32003c30`](https://github.com/NixOS/nixpkgs/commit/32003c3051f73892f5e465d0eb80f3d438e5dde2) | `toil: 5.4.0 -> 5.6.0`                                                                                             |
| [`694e98f8`](https://github.com/NixOS/nixpkgs/commit/694e98f8a61f86fa723503e114b6fcb38d863595) | `python3Packages.py-tes: init at 0.4.2`                                                                            |
| [`85d37ab4`](https://github.com/NixOS/nixpkgs/commit/85d37ab46deb80a14c967fc273d6c76a42348103) | `python3Packages.homematicip: disable failing tests`                                                               |
| [`47619623`](https://github.com/NixOS/nixpkgs/commit/47619623ea15c6464b0e378092d5a46742dd3f9e) | `stm32cubemx: 6.2.1 -> 6.4.0`                                                                                      |
| [`9fa6b9b0`](https://github.com/NixOS/nixpkgs/commit/9fa6b9b025bf67a4b55b3b1cc1e08917b50fc4b0) | `python3Packages.catalogue: disable failing test`                                                                  |
| [`8537ce50`](https://github.com/NixOS/nixpkgs/commit/8537ce50c93f162e70112c2bef0dbc24e2301002) | `python3Packages.hahomematic: 0.21.0 -> 0.21.2`                                                                    |
| [`5f07376b`](https://github.com/NixOS/nixpkgs/commit/5f07376b951dc2285a4043e541019decd29b4b14) | `python3Packages.hahomematic: 0.20.0 -> 0.21.0`                                                                    |
| [`c627a7e4`](https://github.com/NixOS/nixpkgs/commit/c627a7e4e7afa5e6d8c9879afca5d4cbf9e708d3) | `python3Packages.enaml: 0.13.0 -> 0.14.0`                                                                          |
| [`f610a972`](https://github.com/NixOS/nixpkgs/commit/f610a972a2c103a375f53ea41436ae36a8d4bc34) | `python3Packages.hahomematic: 0.19.0 -> 0.20.0`                                                                    |
| [`5d888bff`](https://github.com/NixOS/nixpkgs/commit/5d888bff2777402b4112eed22c7e5287f8e3bf01) | `pijuice: init at 1.7`                                                                                             |
| [`d1838b51`](https://github.com/NixOS/nixpkgs/commit/d1838b51480573593f51242c6da0c7a628afd2d8) | `anytype: 0.22.3 -> 0.23.0`                                                                                        |
| [`e9675aa7`](https://github.com/NixOS/nixpkgs/commit/e9675aa7f9de1b65d8b62513acfc1c10ef6aaba5) | `python3Packages.dacite: disable failing test`                                                                     |
| [`61affb7d`](https://github.com/NixOS/nixpkgs/commit/61affb7d91b9e91da6d17130b258f00a5da18fee) | `chromiumBeta: 98.0.4758.48 -> 98.0.4758.54`                                                                       |
| [`6c0fc251`](https://github.com/NixOS/nixpkgs/commit/6c0fc2514d831ed9c926a35cf9e564ad35d67e4e) | `gdk-pixbuf-xlib: 2020-06-11-unstable -> 2.40.2`                                                                   |
| [`ba97ea6d`](https://github.com/NixOS/nixpkgs/commit/ba97ea6dcbf56f4f826dd540e8f109896c90f3c0) | `ttygif: 1.5.0 -> 1.6.0`                                                                                           |
| [`dd4109a2`](https://github.com/NixOS/nixpkgs/commit/dd4109a2aa3f2318a895d46cdfec52c6419b3cb5) | `tinyssh: 20210601 -> 20220101`                                                                                    |
| [`6ba9a810`](https://github.com/NixOS/nixpkgs/commit/6ba9a810593bed397b257fb5e96ef57759bcbe41) | `git-hub: 2.1.1 -> 2.1.2`                                                                                          |
| [`75f0a6b6`](https://github.com/NixOS/nixpkgs/commit/75f0a6b65baed0fe6c27377eec4dd50255e58e36) | `inadyn: 2.9.0 -> 2.9.1`                                                                                           |
| [`a26feceb`](https://github.com/NixOS/nixpkgs/commit/a26feceb1a4d63779a861717d01d2d57772b6788) | `python3Packages.faraday-plugins: 1.5.9 -> 1.5.10`                                                                 |
| [`09b3ac7a`](https://github.com/NixOS/nixpkgs/commit/09b3ac7aa51ecdcaa169066df8aa6239907fdfe5) | `python3Packages.glom: switch to pytestCheckHook`                                                                  |
| [`2d3dd648`](https://github.com/NixOS/nixpkgs/commit/2d3dd64808ab2d1a631c1f05556fbe59a7143d86) | `scala: 2.13.7 -> 2.13.8`                                                                                          |
| [`37076fc6`](https://github.com/NixOS/nixpkgs/commit/37076fc603a3d38340065f7eebbd4cef0ac2dfc5) | `python3Packages.boltons: add patch for pprint`                                                                    |
| [`89b41c0f`](https://github.com/NixOS/nixpkgs/commit/89b41c0f31844ee58bedbdb6759066abbfcbcbe1) | `proxychains-ng: fix build on aarch64-darwin`                                                                      |
| [`99ee04b5`](https://github.com/NixOS/nixpkgs/commit/99ee04b5d181a43fd6e28e6e1140f58410b5a9e7) | `cryptsetup: 2.4.2 -> 2.4.3`                                                                                       |
| [`441efc81`](https://github.com/NixOS/nixpkgs/commit/441efc81bce144361401f32696aebecea10d99d9) | `libkeyfinder: 2.2.5 -> 2.2.6`                                                                                     |
| [`077a0b2e`](https://github.com/NixOS/nixpkgs/commit/077a0b2ee6d9a317252cf72c0f339d99281d41e2) | `python310Packages.marshmallow-dataclass: ignore DeprecationWarning`                                               |