### PR TITLE
chore(flake/utils): `74f7e431` -> `7e2a3b3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`7e2a3b3d`](https://github.com/numtide/flake-utils/commit/7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249) | `check-utils: use the same success derivation (#75)`                             |
| [`32dc3d46`](https://github.com/numtide/flake-utils/commit/32dc3d46b2854de460e1a0d03cea472fafea5acd) | `filterPackages: Fix a typo in the comment`                                      |
| [`3b6a41d7`](https://github.com/numtide/flake-utils/commit/3b6a41d794bf4217b353f8b5477f903841a300fb) | `filterPackages: Do not use meta.hydraPlatforms for filtering`                   |
| [`3ff4550a`](https://github.com/numtide/flake-utils/commit/3ff4550a66be41ea42dfdd0393744623d00c0559) | `filterPackages: Add support for meta.badPlatforms`                              |
| [`1ed9fb19`](https://github.com/numtide/flake-utils/commit/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1) | `Fix check-utils template directory name (#70)`                                  |
| [`04c1b180`](https://github.com/numtide/flake-utils/commit/04c1b180862888302ddfb2e3ad9eaa63afc60cf8) | `feat: add convenience eachDefaultSystemMap (#60)`                               |
| [`a97445c4`](https://github.com/numtide/flake-utils/commit/a97445c4fcd22ca0d1d5a969972eb24bc819ff3a) | `expose examples as templates (#63)`                                             |
| [`04b4d989`](https://github.com/numtide/flake-utils/commit/04b4d989fda8f14e6fcd1fee631eab9c54d15b97) | `Sanitize the final derivation name to ensure length limits are respected (#66)` |
| [`86115ca0`](https://github.com/numtide/flake-utils/commit/86115ca06b809e102962f1288e0de0ed0822a2a0) | `allSystems: sync with nixpkgs`                                                  |
| [`0d347c56`](https://github.com/numtide/flake-utils/commit/0d347c56f6f41de822a4f4c7ff5072f3382db121) | `use defaultSystems in simpleFlake.nix`                                          |
| [`a4b154eb`](https://github.com/numtide/flake-utils/commit/a4b154ebbdc88c8498a5c7b01589addc9e9cb678) | `Bump cachix/install-nix-action from 16 to 17 (#58)`                             |
| [`0f8662f1`](https://github.com/numtide/flake-utils/commit/0f8662f1319ad6abf89b3380dd2722369fc51ade) | `Bugfix: simpleFlake works only on x86 and Linux (#57)`                          |
| [`eca9b1aa`](https://github.com/numtide/flake-utils/commit/eca9b1aae05b7a7957839eb2e2be08e085c6f037) | `Bump actions/checkout from 2 to 3`                                              |
| [`3cecb5b0`](https://github.com/numtide/flake-utils/commit/3cecb5b042f7f209c56ffd8371b2711a290ec797) | `actually expose eachSystemMap`                                                  |
| [`846b2ae0`](https://github.com/numtide/flake-utils/commit/846b2ae0fc4cc943637d3d1def4454213e203cba) | `Update default.nix (#42)`                                                       |
| [`3f197dc7`](https://github.com/numtide/flake-utils/commit/3f197dc7591cc6edc83e1eb44698283c19fd28a2) | `add system map for convenience (#55)`                                           |