### PR TITLE
chore(flake/gitignore): `f2ea0f8f` -> `a20de23b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658402513,
-        "narHash": "sha256-wk38v/mbLsOo6+IDmmH1H0ADR87iq9QTTD1BP9X2Ags=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "f2ea0f8ff1bce948ccb6b893d15d5ea3efaf1364",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                     | Commit Message                          |
| ---------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`fad6033f`](https://github.com/hercules-ci/gitignore.nix/commit/fad6033fca96a90be36cb04f2779e0bbf7158af5) | `Add extraRules to gitignoreFilterWith` |