### PR TITLE
chore(flake/pre-commit): `60cad1a3` -> `2e4a7089`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663082609,
-        "narHash": "sha256-lmCCIu4dj59qbzkGKHQtolhpIEQMeAd2XUbXVPqgPYo=",
+        "lastModified": 1664708386,
+        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "60cad1a326df17a8c6cf2bb23436609fdd83024e",
+        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                                       |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`1d9721d0`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d9721d04974f738b12ca5e9748bd683518785ed) | ``Run nixpkgs-fmt on `modules/hooks.nix```                           |
| [`4884c714`](https://github.com/cachix/pre-commit-hooks.nix/commit/4884c714d67ea89ed6adf49601adf6b2c64eeab0) | `Add support for deadnix`                                            |
| [`efcbfd78`](https://github.com/cachix/pre-commit-hooks.nix/commit/efcbfd78c7ec5748114b33cb48a6b26ddb7e29dd) | `Add dhall-format for formatting Dhall code`                         |
| [`e48619d6`](https://github.com/cachix/pre-commit-hooks.nix/commit/e48619d65be73a2fc1c80ea5c3036b3c5c31caa2) | `fix(nix/tools): get chktex, latexindent from texlive.scheme-medium` |
| [`b29df527`](https://github.com/cachix/pre-commit-hooks.nix/commit/b29df5277e316f2c8845532c49c6a9d03d449485) | `style(nix/tools): also sort inherits and callPackage lines`         |
| [`b35118da`](https://github.com/cachix/pre-commit-hooks.nix/commit/b35118daf6afc1f4c5f09dde0e02a9c15d2bf2d1) | `feat(modules/hooks): add latexindent`                               |
| [`65348b66`](https://github.com/cachix/pre-commit-hooks.nix/commit/65348b66411582328a68158696e89a85f38ec646) | `feat(modules/hooks): add chktex`                                    |
| [`d21b1161`](https://github.com/cachix/pre-commit-hooks.nix/commit/d21b1161b05c65f46c9af8b54cb1e3195f7141cb) | `style(nix/tools): sort inputs`                                      |
| [`3424c610`](https://github.com/cachix/pre-commit-hooks.nix/commit/3424c6107bde3bdb84eada83db7f4bc6f0d346e4) | `feat(modules/hooks): add actionlint`                                |
| [`02e36c77`](https://github.com/cachix/pre-commit-hooks.nix/commit/02e36c77d93f04fc29cc4ba31ec4659f30056f31) | `feat(modules/hooks): add luacheck`                                  |