### PR TITLE
chore(flake/nixpkgs): `b78c3a22` -> `59fa082a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664176151,
-        "narHash": "sha256-Mq6ILBJf0ieyR80Nt3gFADOiZXeoPVbNlTcoCk71/4g=",
+        "lastModified": 1703834000,
+        "narHash": "sha256-SafYHMNd45Ca+ujIoNd0Ucf+sFSftRn1XYX/TdJL3TY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b78c3a22f388bd5320f664101d22885408b7898e",
+        "rev": "59fa082abdbf462515facc8800d517f5728c909d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`fa182d59`](https://github.com/NixOS/nixpkgs/commit/fa182d59bf171de970c5f0c5e503c72207bfe087) | `onetun: 0.3.6 -> 0.3.7`                                                               |
| [`a3957236`](https://github.com/NixOS/nixpkgs/commit/a3957236ce752b03d0ba3c388422b730129c6085) | ``cargo: fix `tests` eval``                                                            |
| [`d363b99f`](https://github.com/NixOS/nixpkgs/commit/d363b99f1afc34aa7e192bd01cb049bb87d0770c) | `cargo-expand: 1.0.75 -> 1.0.77`                                                       |
| [`4f31d4ab`](https://github.com/NixOS/nixpkgs/commit/4f31d4ab8a900a370a5147b2aa2a84061a8c2b30) | `python310Packages.pyngrok: 7.0.3 -> 7.0.4`                                            |
| [`fb8c363b`](https://github.com/NixOS/nixpkgs/commit/fb8c363b6ac8d4bc2dee0e65b6b9d0cc657bd6f6) | `doc: fix python-updates branch name`                                                  |
| [`cfdb96ec`](https://github.com/NixOS/nixpkgs/commit/cfdb96ec524972f313210874744d79393c757111) | `linux/hardened/patches/5.15: 5.15.144-hardened1 -> 5.15.145-hardened1`                |
| [`0f52666e`](https://github.com/NixOS/nixpkgs/commit/0f52666e61f4bca1f6c134db9ef99d796837d1b2) | `linux_latest-libre: 19441 -> 19453`                                                   |
| [`269e0c31`](https://github.com/NixOS/nixpkgs/commit/269e0c31e9f8eeeb91e0cd7afae8f497ad4f9197) | `linux-rt_5_10: 5.10.201-rt98 -> 5.10.204-rt100`                                       |
| [`45ae51d6`](https://github.com/NixOS/nixpkgs/commit/45ae51d6d183ea4c1d7cecd15707d655af32328d) | `linux_5_15: 5.15.144 -> 5.15.145`                                                     |
| [`b76c2082`](https://github.com/NixOS/nixpkgs/commit/b76c2082ead2cbc13f8cc2c55b158eadeb1bc31b) | `linux_testing: 6.7-rc6 -> 6.7-rc7`                                                    |
| [`b908e175`](https://github.com/NixOS/nixpkgs/commit/b908e175181a6d7df32cfa8d426fdffc5f7348fd) | `maintainers/teams: remove primeos from the llvm team`                                 |
| [`fdc70103`](https://github.com/NixOS/nixpkgs/commit/fdc70103c0d8c9b34cb3258bd3966e53af691b16) | `python3Packages.gpxpy: 1.5.0 → 1.6.2`                                                 |
| [`3f8b1d2d`](https://github.com/NixOS/nixpkgs/commit/3f8b1d2d26364f9f627055387804900f3f1e0624) | `nixos/lxd-agent: add system path for exec`                                            |
| [`d57d1d61`](https://github.com/NixOS/nixpkgs/commit/d57d1d61b6de6eeced2db3eb5f70097a59adfad2) | `cppcheck: 2.12.1 -> 2.13.0`                                                           |
| [`9d0caade`](https://github.com/NixOS/nixpkgs/commit/9d0caade842caea4217b3804eea85dee3a681fc8) | `terraform-providers.incus: init at 0.0.2`                                             |
| [`d578efaf`](https://github.com/NixOS/nixpkgs/commit/d578efaf68775aa11577d0952f64a771c1fdde96) | `aiac: 2.5.0 -> 4.0.0`                                                                 |
| [`41c97a95`](https://github.com/NixOS/nixpkgs/commit/41c97a952d1024f173b3ff125ff47600ff648db8) | `python310Packages.oelint-parser: 2.12.1 -> 2.12.3`                                    |
| [`f88af993`](https://github.com/NixOS/nixpkgs/commit/f88af99311e688f02fbffe29df3a608a0b14756e) | `nixos/aerospike: use NixOS option instead of custom script`                           |
| [`8cdabf9c`](https://github.com/NixOS/nixpkgs/commit/8cdabf9cf8ce16babb2342e39bd44e85fc3d8f28) | `nixos/sysctl: cleanup`                                                                |
| [`823c595d`](https://github.com/NixOS/nixpkgs/commit/823c595d1cd6feba877d0a7aa45480a65f9812fb) | `djlint: 1.32.1 -> 1.34.1`                                                             |
| [`2e79ed82`](https://github.com/NixOS/nixpkgs/commit/2e79ed82ce71c14db7512f6a72c44443f3d2cabd) | `podman-tui: 0.14.0 -> 0.15.0`                                                         |
| [`4096c904`](https://github.com/NixOS/nixpkgs/commit/4096c9043f69d4b56876e2e31baf4b9b462da9ba) | `nfpm: 2.35.0 -> 2.35.1`                                                               |
| [`50e01aa1`](https://github.com/NixOS/nixpkgs/commit/50e01aa1cce23a487e23d8df56e620d308dc2968) | `python3Packages.simple-term-menu: init at 1.6.4`                                      |
| [`d7324eb2`](https://github.com/NixOS/nixpkgs/commit/d7324eb2c9c251609561801ff4baf0d8e3ee7929) | `maintainers: add smrehman`                                                            |
| [`978c5302`](https://github.com/NixOS/nixpkgs/commit/978c5302b24c11e5f1b5e593bcc13fb7dd15783d) | `checkov: 3.1.44 -> 3.1.46`                                                            |
| [`cfaa99f6`](https://github.com/NixOS/nixpkgs/commit/cfaa99f6261d72fe31735d2c7837e186be3159d9) | `pluto: 5.19.0 -> 5.19.1`                                                              |
| [`685b4096`](https://github.com/NixOS/nixpkgs/commit/685b4096784ca72199627bd2b51d5756c23b44d4) | `python311Packages.aioairzone-cloud: 0.3.6 -> 0.3.7`                                   |
| [`88f719ac`](https://github.com/NixOS/nixpkgs/commit/88f719acbf6b09779722470de8f5d64264c0cc9a) | `unpaper: add meta.changelog`                                                          |
| [`5751106b`](https://github.com/NixOS/nixpkgs/commit/5751106b6059fb6ebd34a5bf82f3e42ee2a8cae2) | `tipidee: 0.0.2.0 -> 0.0.3.0`                                                          |
| [`09bb287f`](https://github.com/NixOS/nixpkgs/commit/09bb287faabe4cd6ec2a0c377880a5a511a16ca0) | `s6-dns: 2.3.7.0 -> 2.3.7.1`                                                           |
| [`626df9ec`](https://github.com/NixOS/nixpkgs/commit/626df9ec03343ee7b6aedd06315d080bd2787bae) | `s6-networking: 2.7.0.0 -> 2.7.0.1`                                                    |
| [`b2e3c3c5`](https://github.com/NixOS/nixpkgs/commit/b2e3c3c5509752948f9ccf77b574870927061d77) | `s6: 2.12.0.2 -> 2.12.0.3`                                                             |
| [`e9dbcaa4`](https://github.com/NixOS/nixpkgs/commit/e9dbcaa4029af7bce4bc6f29fd7dfa8f95ea5a9a) | `skalibs: 2.14.0.1 -> 2.14.1.0`                                                        |
| [`85fa37af`](https://github.com/NixOS/nixpkgs/commit/85fa37afc234de26d57926963d641bd42c7ccb2b) | `lighttpd.meta.mainProgram: init`                                                      |
| [`16d613b3`](https://github.com/NixOS/nixpkgs/commit/16d613b330198adb50909157eb6fa07d27c3fbb5) | `pict-rs: 0.4.6 -> 0.4.7`                                                              |
| [`84f73ec7`](https://github.com/NixOS/nixpkgs/commit/84f73ec7b56510d2ff429ab17ca77225537331b5) | `python311Packages.homeassistant-stubs: 2023.12.3 -> 2023.12.4`                        |
| [`1b1aa5c5`](https://github.com/NixOS/nixpkgs/commit/1b1aa5c5ec1c43df9379f82b78ec543c75120ffc) | `home-assistant: 2023.12.3 -> 2023.12.4`                                               |
| [`c3e2e79d`](https://github.com/NixOS/nixpkgs/commit/c3e2e79d6e029b29618a427e42a6b9e6f9850751) | `ooniprobe-cli: 3.20.0 -> 3.20.1`                                                      |
| [`9acd7a17`](https://github.com/NixOS/nixpkgs/commit/9acd7a1737d5f6c8b9984ab2af3e2593d5593cdf) | `Revert "archivebox: 0.6.2 -> 0.7.1"`                                                  |
| [`bbaaa76e`](https://github.com/NixOS/nixpkgs/commit/bbaaa76e774723b926f7a67a2ab9d37fd3ad0cc4) | `libao: Fix eval when config.pulseaudio is set`                                        |
| [`4b2912c5`](https://github.com/NixOS/nixpkgs/commit/4b2912c5fbbc3f5348403626fc0eb59046029372) | `python311Packages.arviz: 0.16.1 -> 0.17.0`                                            |
| [`497dafce`](https://github.com/NixOS/nixpkgs/commit/497dafcea056207ab2476bb23d26d78e2f0038e0) | `asusctl: 5.0.2 -> 5.0.6`                                                              |
| [`abb91d7b`](https://github.com/NixOS/nixpkgs/commit/abb91d7be3b327a7c58542623fed8a978246cd69) | `monkeysAudio: 10.30 -> 10.38`                                                         |
| [`ee5ff73c`](https://github.com/NixOS/nixpkgs/commit/ee5ff73cfb247391cfcee22fae35c589b599d242) | `doublecmd: 1.1.7 -> 1.1.8`                                                            |
| [`5a890624`](https://github.com/NixOS/nixpkgs/commit/5a890624383b0dbc4a7522a289535ae501f2d3a7) | `python311Packages.zha-quirks: 0.0.108 -> 0.0.109`                                     |
| [`f2a8ed25`](https://github.com/NixOS/nixpkgs/commit/f2a8ed2545db54780954645d9a660dffbee175d4) | `qovery-cli: 0.76.0 -> 0.77.0`                                                         |
| [`3f0ccf93`](https://github.com/NixOS/nixpkgs/commit/3f0ccf9352dcc1b3039086e36787663a0a3f2530) | `python311Packages.losant-rest: 1.19.2 -> 1.19.3`                                      |
| [`5f1c63ac`](https://github.com/NixOS/nixpkgs/commit/5f1c63ac1f1d0d7cbbd0bc2913362cd7655ec1be) | ``nodePackages.@antora/cli: fix eval by removing `main-programs.nix` entry``           |
| [`47d3395b`](https://github.com/NixOS/nixpkgs/commit/47d3395b00494e2601f019347e7f1e1d4ab54522) | `cloudfoundry-cli: 8.7.6 -> 8.7.7`                                                     |
| [`aaa37c5d`](https://github.com/NixOS/nixpkgs/commit/aaa37c5df3f963a808722d519bbf93d7db15fbfa) | `cargo-mobile2: 0.9.0 -> 0.9.1`                                                        |
| [`60e3f7e3`](https://github.com/NixOS/nixpkgs/commit/60e3f7e322099518e52de6d4958f4fcf490f7896) | `uthenticode: 2.0.0 -> 2.0.1`                                                          |
| [`0a2a67c3`](https://github.com/NixOS/nixpkgs/commit/0a2a67c3db6b0ba52a4e06be26976568df103ae5) | `sketchybar-app-font: 1.0.20 -> 1.0.21`                                                |
| [`64cb07fe`](https://github.com/NixOS/nixpkgs/commit/64cb07fee6beaea0a238f89f9ae1f51073527894) | `svls: 0.2.10 -> 0.2.11`                                                               |
| [`e036cfa8`](https://github.com/NixOS/nixpkgs/commit/e036cfa87a9ef62239281e725c0a16f0a59fd3e2) | `pdfhummus: 4.6.1 -> 4.6.2`                                                            |
| [`0dc7c4d1`](https://github.com/NixOS/nixpkgs/commit/0dc7c4d1902aea22687660e4df0302def5171f80) | `python311Packages.evohome-async: 0.4.15 -> 0.4.16`                                    |
| [`8e4c0b99`](https://github.com/NixOS/nixpkgs/commit/8e4c0b99a679173f6e0660cee21b8e092ed88dc3) | `python311Packages.elgato: 5.1.1 -> 5.1.2`                                             |
| [`1765936f`](https://github.com/NixOS/nixpkgs/commit/1765936f5ac1ae556ea4adf8e7814c029bfad949) | `svlint: 0.9.1 -> 0.9.2`                                                               |
| [`5920a80f`](https://github.com/NixOS/nixpkgs/commit/5920a80f0222ec610b659220f9003f79aee57de1) | `katago: 1.13.1 -> 1.14.0`                                                             |
| [`1c6a5c70`](https://github.com/NixOS/nixpkgs/commit/1c6a5c70522655b648fb5c1a1ab80890534b1023) | `dwarfs: 0.7.3 -> 0.7.4`                                                               |
| [`8f2b8250`](https://github.com/NixOS/nixpkgs/commit/8f2b825017be008eb0cd05c5ab72b71828fd2b8f) | `python311Packages.wavinsentio: 0.4.0 -> 0.4.1`                                        |
| [`0f376a4e`](https://github.com/NixOS/nixpkgs/commit/0f376a4eed6855f7852d7a41f8d5d4995c5f9405) | `python311Packages.pyatmo: 8.0.1 -> 8.0.2`                                             |
| [`0ea859af`](https://github.com/NixOS/nixpkgs/commit/0ea859af92f7da64d1e0394e0dd777db075b7047) | `amber: 0.5.9 -> 0.6.0`                                                                |
| [`15a672bf`](https://github.com/NixOS/nixpkgs/commit/15a672bf1f329115270ba2e63b0d4f0e49e58098) | ``nixosTests.tomcat: add `lib` to imports to fix eval``                                |
| [`4e1d0581`](https://github.com/NixOS/nixpkgs/commit/4e1d0581c117ac4dc1cc795c777ddacc040c1f45) | `kanshi: 1.4.0 -> 1.5.0`                                                               |
| [`e3e3eff4`](https://github.com/NixOS/nixpkgs/commit/e3e3eff41cc3c97ca2d6029b1a8da668b1e65a5a) | `gpxsee-qt6: 13.12 -> 13.13`                                                           |
| [`73332dcb`](https://github.com/NixOS/nixpkgs/commit/73332dcbd82560298fb45265e97601ad34c3de28) | `apprise: 1.6.0 -> 1.7.0`                                                              |
| [`d6990a64`](https://github.com/NixOS/nixpkgs/commit/d6990a647829023ea6df2e2ac6819ca31389e02a) | `starship: 1.16.0 -> 1.17.0`                                                           |
| [`83268ad0`](https://github.com/NixOS/nixpkgs/commit/83268ad06280b15138a4caa4f218da5342e8e4ef) | `python310Packages.linien-common: 1.0.0 -> 1.0.1`                                      |
| [`b22e9cb8`](https://github.com/NixOS/nixpkgs/commit/b22e9cb85999a8fe9662e95e92abd469db769e18) | `python310Packages.lcgit: 0.2.0 -> 0.2.1`                                              |
| [`e7b0d049`](https://github.com/NixOS/nixpkgs/commit/e7b0d0499304485d893b7b9533d828d152fe9096) | `python310Packages.langsmith: 0.0.72 -> 0.0.75`                                        |
| [`43dc0390`](https://github.com/NixOS/nixpkgs/commit/43dc0390242137d9ccf6df8c8753deebb41ddcb4) | `python310Packages.kornia: 0.7.0 -> 0.7.1`                                             |
| [`7f364a5a`](https://github.com/NixOS/nixpkgs/commit/7f364a5a9cec738b467753eafa8c8658f4460d5d) | `prqlc: 0.10.1 -> 0.11.1`                                                              |
| [`4c3c8d60`](https://github.com/NixOS/nixpkgs/commit/4c3c8d6041edb579575974ed5b4e8525f442bb4a) | `kubeclarity: 2.22.1 -> 2.23.0`                                                        |
| [`13be39c2`](https://github.com/NixOS/nixpkgs/commit/13be39c2aefef04316a1cc840fc9630ca088dc1c) | `cntr: 1.5.2 -> 1.5.3`                                                                 |
| [`04d91e68`](https://github.com/NixOS/nixpkgs/commit/04d91e680429dd6a36417aac7d04b2081997c1fe) | `cloudfox: 1.12.3 -> 1.13.0`                                                           |
| [`0583bcd6`](https://github.com/NixOS/nixpkgs/commit/0583bcd6df113b06bf6574f147644321f532e843) | `python310Packages.enlighten: 1.12.3 -> 1.12.4`                                        |
| [`272a5d14`](https://github.com/NixOS/nixpkgs/commit/272a5d14682a98f9867140916647a0b31c057165) | `cnquery: 9.12.0 -> 9.12.1`                                                            |
| [`7dbad048`](https://github.com/NixOS/nixpkgs/commit/7dbad0481f6a50f9a887a6a2c888df52de35d133) | `python310Packages.hvplot: 0.9.0 -> 0.9.1`                                             |
| [`ce097af2`](https://github.com/NixOS/nixpkgs/commit/ce097af2601860e7499ce1bd1e61e8403c0f1977) | `python310Packages.graphene-django: 3.1.5 -> 3.2.0`                                    |
| [`17d74cea`](https://github.com/NixOS/nixpkgs/commit/17d74ceaf1051069064be3f6e1015604d8c5c7b8) | `python310Packages.garminconnect: 0.2.11 -> 0.2.12`                                    |
| [`0493e502`](https://github.com/NixOS/nixpkgs/commit/0493e502bbf474f293e8453213d8e438232f082a) | `python310Packages.garth: 0.4.41 -> 0.4.42`                                            |
| [`59fcbd9e`](https://github.com/NixOS/nixpkgs/commit/59fcbd9e2a48184e9e97f3c754726d790bae711b) | `rpi-imager: set meta.homepage to something useful, don't use finalAttrs.pname in src` |
| [`1b7cd426`](https://github.com/NixOS/nixpkgs/commit/1b7cd426f98d7fd736d3a35f74704edde79b0c92) | `python311Packages.einops: remove chainer from nativeCheckInputs`                      |
| [`d6124574`](https://github.com/NixOS/nixpkgs/commit/d6124574ea191e088e412e23cd83f26fefec3ed9) | `sea-orm-cli: 0.12.2 -> 0.12.10`                                                       |
| [`8cb85ce2`](https://github.com/NixOS/nixpkgs/commit/8cb85ce23d7456614c4cfa7df92c1b9ef341d64f) | `python3Packages.ptpython: remove now superfluous black dependency`                    |
| [`022cbac1`](https://github.com/NixOS/nixpkgs/commit/022cbac13d34b6f839b2e2c30837923d8cdab336) | `neovim: make generated wrapper args overridable`                                      |
| [`834d0389`](https://github.com/NixOS/nixpkgs/commit/834d0389341454f6348028faa0b524cb322dacb2) | `kubedog: 0.10.0 -> 0.11.0`                                                            |
| [`8c1dcd85`](https://github.com/NixOS/nixpkgs/commit/8c1dcd8539cacad7874362dcf5622ad9a9e95ea0) | `python310Packages.faraday-plugins: 1.15.0 -> 1.15.1`                                  |
| [`032d45b4`](https://github.com/NixOS/nixpkgs/commit/032d45b46c6e39a864570628d9f110454dbf4c66) | `fstar: build with dune (#275924)`                                                     |
| [`26e21bef`](https://github.com/NixOS/nixpkgs/commit/26e21bef1477b8cec699324a19da8876a077e43e) | `python310Packages.django-webpack-loader: 2.0.1 -> 3.0.0`                              |
| [`c53dd4b2`](https://github.com/NixOS/nixpkgs/commit/c53dd4b2127e2751d321ce756793ebdfd4e395eb) | `nitter: use guest_accounts branch in updateScript`                                    |
| [`6254d0ce`](https://github.com/NixOS/nixpkgs/commit/6254d0ce133c0c25876016869adc83d58abcccf2) | `python310Packages.django-import-export: 3.3.4 -> 3.3.5`                               |