### PR TITLE
chore(flake/flake-utils): `c0e246b9` -> `4022d587`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -80,6 +83,21 @@
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs",
         "pre-commit": "pre-commit"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`4022d587`](https://github.com/numtide/flake-utils/commit/4022d587cbbfd70fe950c1e2083a02621806a725) | `Bump cachix/install-nix-action from 23 to 24 (#109)`                      |
| [`ff7b65b4`](https://github.com/numtide/flake-utils/commit/ff7b65b44d01cf9ba6a71320833626af21126384) | `Bump cachix/install-nix-action from 22 to 23 (#106)`                      |
| [`286e744c`](https://github.com/numtide/flake-utils/commit/286e744c9654ef158fd3b9ef2526966ba41ebf58) | `Bump actions/checkout from 3 to 4 (#105)`                                 |
| [`1721b3e7`](https://github.com/numtide/flake-utils/commit/1721b3e7c882f75f2301b00d48a2884af8c448ae) | `README: add light commercial support offer`                               |
| [`919d646d`](https://github.com/numtide/flake-utils/commit/919d646de7be200f3bf08cb76ae1f09402b6f9b4) | `Fix typo in ReadMe (#95)`                                                 |
| [`dbabf0ca`](https://github.com/numtide/flake-utils/commit/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7) | `Add meld (#99)`                                                           |
| [`abfb11bd`](https://github.com/numtide/flake-utils/commit/abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c) | `Bump cachix/install-nix-action from 21 to 22 (#100)`                      |
| [`180473db`](https://github.com/numtide/flake-utils/commit/180473db908bf08c74298bccdf969580237be716) | `Add test to ensure no special handling of hydraJobs`                      |
| [`9e0a97e0`](https://github.com/numtide/flake-utils/commit/9e0a97e02654b788ccdfaafe2c719bc0f8411cd6) | `No special treatment for hydraJobs`                                       |
| [`a1720a10`](https://github.com/numtide/flake-utils/commit/a1720a10a6cfe8234c0e93907ffe81be440f4cef) | `Bump cachix/install-nix-action from 20 to 21 (#96)`                       |
| [`cfacdce0`](https://github.com/numtide/flake-utils/commit/cfacdce06f30d2b68473a46042957675eebb3401) | `REAMDE: document the systems pattern a bit more`                          |
| [`033b9f25`](https://github.com/numtide/flake-utils/commit/033b9f258ca96a10e543d4442071f614dc3f8412) | `clean flake check warnings`                                               |
| [`2f02e38d`](https://github.com/numtide/flake-utils/commit/2f02e38dfa6cf8afb4d830aad171d8d7cf100c06) | `update allSystems.nix`                                                    |
| [`575419ad`](https://github.com/numtide/flake-utils/commit/575419ad23de2f2886a3905163a29b854793338d) | `split out allSystems.nix`                                                 |
| [`471aed54`](https://github.com/numtide/flake-utils/commit/471aed544aef9c610ea465cddf4a39c358ac5aa8) | `fixup! introduce externally extensible systems (#93)`                     |
| [`1c226cc8`](https://github.com/numtide/flake-utils/commit/1c226cc8c6562379ffd0ac36ca095396250d94d7) | `introduce externally extensible systems (#93)`                            |
| [`13faa43c`](https://github.com/numtide/flake-utils/commit/13faa43c34c0c943585532dacbb457007416d50b) | `Use less confusing syntax (#85)`                                          |
| [`946da791`](https://github.com/numtide/flake-utils/commit/946da791763db1c306b86a8bd3828bf5814a1247) | ``Update documentation for the `systems` argument of `simpleFlake` (#92)`` |
| [`411e8764`](https://github.com/numtide/flake-utils/commit/411e8764155aa9354dbcd6d5faaeb97e9e3dce24) | `Bump cachix/install-nix-action from 19 to 20 (#89)`                       |
| [`93a2b84f`](https://github.com/numtide/flake-utils/commit/93a2b84fc4b70d9e089d029deacc3583435c2ed6) | `Update README to reflect example for eachDefaultSystem (#90)`             |
| [`3db36a8b`](https://github.com/numtide/flake-utils/commit/3db36a8b464d0c4532ba1c7dda728f4576d6d073) | `Bump cachix/install-nix-action from 18 to 19 (#87)`                       |
| [`5aed5285`](https://github.com/numtide/flake-utils/commit/5aed5285a952e0b949eb3ba02c12fa4fcfef535f) | `remove 20 years old arch (#82)`                                           |
| [`6ee9ebb6`](https://github.com/numtide/flake-utils/commit/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817) | `Bump cachix/install-nix-action from 17 to 18 (#81)`                       |