### PR TITLE
chore(flake/gitignore): `a20de23b` -> `43e1aa13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                     | Commit Message                                              |
| ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`43e1aa13`](https://github.com/hercules-ci/gitignore.nix/commit/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5) | `Update README.md`                                          |
| [`02c007b3`](https://github.com/hercules-ci/gitignore.nix/commit/02c007b372999722e9435208d005fbeeca305f7a) | `Reminder to port the tests`                                |
| [`b5594318`](https://github.com/hercules-ci/gitignore.nix/commit/b5594318e5b8118c302b82099b75cdfb25f6ea92) | `Fix dir with ignored contents bug`                         |
| [`17ab30e0`](https://github.com/hercules-ci/gitignore.nix/commit/17ab30e0a9fc11aba444ea59fb2ecca41329fe36) | `flake.lock: Update`                                        |
| [`1a2cd169`](https://github.com/hercules-ci/gitignore.nix/commit/1a2cd1693215e33aa8186b7b1754ed72342ff174) | `flake.nix: Wire the checks`                                |
| [`2eddf711`](https://github.com/hercules-ci/gitignore.nix/commit/2eddf71196502466ef4f8e6c6380c08ca5e1c048) | `flake.nix: description: does not have to be git`           |
| [`49e5d6da`](https://github.com/hercules-ci/gitignore.nix/commit/49e5d6daf3a4531fc6736c8b74032e26eae8d145) | `Format`                                                    |
| [`3f4a7961`](https://github.com/hercules-ci/gitignore.nix/commit/3f4a79613d027433736a673a9ccffe1985b104b4) | `Add failing test case for directory with ignored contents` |