### PR TITLE
chore(flake/nixpkgs): `7a7cfff8` -> `b4ee3c3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704397097,
-        "narHash": "sha256-ywXj6ck6q5ArzzRk9wXQX4rGnxdwS/xOCkibrMXOykc=",
+        "lastModified": 1705692095,
+        "narHash": "sha256-iJazHf0FQjuIplTEvDHMkByxQD1kyCp4Cm78krkf3N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a7cfff8915e06365bc2365ff33d4d413184fa9f",
+        "rev": "b4ee3c3cc4b63315702e09858f6b517bdd249b3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`81d9d36e`](https://github.com/NixOS/nixpkgs/commit/81d9d36ea9176b910425d9bee802f649a1bb2e05) | `` bsync: init at unstable-2023-12-21 ``                                          |
| [`e87c2dd2`](https://github.com/NixOS/nixpkgs/commit/e87c2dd226c07fed4105130bd1d82600338a9329) | `` graalvmCEPackages.truffleruby: 23.1.1 -> 23.1.2 ``                             |
| [`91029222`](https://github.com/NixOS/nixpkgs/commit/910292224c11bf9748e5ca2c64dd341e70ac1642) | `` xfs_undelete:  init at unstable-2023-04-12 ``                                  |
| [`93360c80`](https://github.com/NixOS/nixpkgs/commit/93360c805840a3e66555d17ce5a380082ead0822) | `` vimPlugins.nvim-treesitter: update grammars ``                                 |
| [`02cf44d8`](https://github.com/NixOS/nixpkgs/commit/02cf44d84292d34122ff71ba7567c7eb6513a5ec) | `` vimPlugins: update on 2024-01-19 ``                                            |
| [`64b7d933`](https://github.com/NixOS/nixpkgs/commit/64b7d93385f0aff8a842460ab28c9501aa480106) | `` vimPlugins.cmp-tabby: init at 2023-11-21 ``                                    |
| [`ee0312bc`](https://github.com/NixOS/nixpkgs/commit/ee0312bcffe510b10eaf05c56ec57d9df563f29e) | `` nixos/tests/nginx: add test variant for moreheaders module ``                  |
| [`156d23e1`](https://github.com/NixOS/nixpkgs/commit/156d23e183fa53b04b45597ee33840627e4df374) | `` fastnetmon-advanced: 2.0.357 -> 2.0.358 (#281564) ``                           |
| [`3956c307`](https://github.com/NixOS/nixpkgs/commit/3956c307f48f7f39e49992abe04a1501f0d434c1) | `` python311Packages.flake8-bugbear: 23.12.2 -> 24.1.17 ``                        |
| [`e99651a8`](https://github.com/NixOS/nixpkgs/commit/e99651a836b162b48fbf4195e0c8d3028b6b32a8) | `` bun: 1.0.22 -> 1.0.23 ``                                                       |
| [`c8b65796`](https://github.com/NixOS/nixpkgs/commit/c8b6579690d81480708721dfe0264c19c9080641) | `` vimPlugins.vscode-nvim: init at 2023-12-21 ``                                  |
| [`47d52594`](https://github.com/NixOS/nixpkgs/commit/47d52594a272bcf5a1f7009aa1ddded711a2fd40) | `` budgiePlugins.budgie-media-player-applet: init at 1.0.0-unstable-2023-12-31 `` |
| [`2efbd63d`](https://github.com/NixOS/nixpkgs/commit/2efbd63dd30f8f45263fb49e6c9b1b66c614b5b4) | `` vimPlugins.nvim-docs-view: init at 2023-10-19 ``                               |
| [`716c2bc9`](https://github.com/NixOS/nixpkgs/commit/716c2bc96ae57cedec031b5e569dc8acaaec2e06) | `` vimPlugins.tailwindcss-colors-nvim: init at 2021-12-24 ``                      |
| [`d7dabbba`](https://github.com/NixOS/nixpkgs/commit/d7dabbba29c88f89b4c3ec36378fee889535c676) | `` incus: add missing service dependencies ``                                     |
| [`0bea6f4a`](https://github.com/NixOS/nixpkgs/commit/0bea6f4a3745d9226f6c16bf8d5dbfe7c2a29806) | `` python311Packages.sqlglot: 17.14.2 -> 20.9.0 ``                                |
| [`7c92405b`](https://github.com/NixOS/nixpkgs/commit/7c92405b7724f65f80f8e8fff4bd9db29cb7fea4) | `` python311Packages.sqlglot: refactor ``                                         |
| [`a45d9642`](https://github.com/NixOS/nixpkgs/commit/a45d9642f9fbfbc6b656e77125a1c42600feeffe) | `` python3Packages.django4: allow build on python >= 3.8 (#282061) ``             |
| [`103c126b`](https://github.com/NixOS/nixpkgs/commit/103c126b974b6888121ebb02fc4a2047846afdc8) | `` python311Packages.griffe: 0.39.0 -> 0.39.1 ``                                  |
| [`e4379505`](https://github.com/NixOS/nixpkgs/commit/e43795052af6ae19d7b5b5c27befd5c7b743220c) | `` reindeer: unstable-2024-01-11 -> unstable-2024-01-12 ``                        |
| [`dcc2daab`](https://github.com/NixOS/nixpkgs/commit/dcc2daabfedbd0fe71a0182e4adfcebc97c31dfb) | `` python311Packages.google-cloud-tasks: refactor ``                              |
| [`4a75beb1`](https://github.com/NixOS/nixpkgs/commit/4a75beb11794888d18cec9b27e707d2225c317f9) | `` python311Packages.google-cloud-tasks: 2.15.0 -> 2.15.1 ``                      |
| [`9104ad47`](https://github.com/NixOS/nixpkgs/commit/9104ad473f8087a2d3164af9412b84feee34f12c) | `` pythonPackages.pdfrw2: init at 0.5.0 ``                                        |
| [`a34af9a9`](https://github.com/NixOS/nixpkgs/commit/a34af9a9556e205fe0a72014a335b96037b41823) | `` image/repart: add version and compression options ``                           |
| [`380daec1`](https://github.com/NixOS/nixpkgs/commit/380daec1e469bbdae4376ab350021db81d02f579) | `` tippecanoe: 2.40.0 -> 2.41.0 ``                                                |
| [`c9e73449`](https://github.com/NixOS/nixpkgs/commit/c9e73449508b9ded9f7fdc0c8a0f81717139a669) | `` Update systemd-boot.nix ``                                                     |
| [`45f1aab3`](https://github.com/NixOS/nixpkgs/commit/45f1aab3d6a9e691dd687fd0df9b694875d114fd) | `` draco: 1.5.6 -> 1.5.7 ``                                                       |
| [`9a45447a`](https://github.com/NixOS/nixpkgs/commit/9a45447ae2ae231b4e48318a083f13f0c4c5ca21) | `` ausweisapp: 2.0.2 -> 2.0.3 ``                                                  |
| [`e7fad70b`](https://github.com/NixOS/nixpkgs/commit/e7fad70b034489cc23e96148e7f46fdc16a6acfb) | `` tigerbeetle: fix build after 0.14.174 ``                                       |
| [`0a554ce2`](https://github.com/NixOS/nixpkgs/commit/0a554ce2c94b4962b7aba88754583b6365f17715) | `` fllog: 1.2.7 -> 1.2.8 ``                                                       |
| [`a455c5fb`](https://github.com/NixOS/nixpkgs/commit/a455c5fb3ee513e2f443838a0e84d52b035adb67) | `` Revert "linux: drop XEN on 32-bit" ``                                          |
| [`3fd2c02d`](https://github.com/NixOS/nixpkgs/commit/3fd2c02d5282ebf961086d5084fcf75781b801e8) | `` python311Packages.pulp: 2.7.0 -> 2.8.0 ``                                      |
| [`2c6c87de`](https://github.com/NixOS/nixpkgs/commit/2c6c87dec2a3bd3cb339ad9f9fd04058f16c18d6) | `` python312Packages.types-psycopg2: 2.9.21.20240106 -> 2.9.21.20240118 ``        |
| [`a7a63119`](https://github.com/NixOS/nixpkgs/commit/a7a6311949534f0e72cdef0f78440eadf6b850c9) | `` _0xproto: 1.300 -> 1.500 ``                                                    |
| [`da74a753`](https://github.com/NixOS/nixpkgs/commit/da74a7530392893791ad28a2e4e58e6fc88f011f) | `` doc: fix typo ``                                                               |
| [`8ef7c0b8`](https://github.com/NixOS/nixpkgs/commit/8ef7c0b86ad76d531c97209d2f0b9e49a3450352) | `` manticoresearch: 6.2.0 -> 6.2.12 ``                                            |
| [`49e703cd`](https://github.com/NixOS/nixpkgs/commit/49e703cde28bc7cbd3042d4709db9a21f9f84537) | `` Add Coqeal 2.0.1 and algebra-tactics 1.2.3 ``                                  |
| [`a276e8b0`](https://github.com/NixOS/nixpkgs/commit/a276e8b09bf0eb21ff2f46cf8680edc16cc517c2) | ``  top-level: use callPackages where inheriting packages ``                      |
| [`5de9f63c`](https://github.com/NixOS/nixpkgs/commit/5de9f63c43f376d6be53e2b2d954c7d63c964b44) | `` python311Packages.pyprusalink: 2.0.0 -> 2.0.1 ``                               |
| [`39502fae`](https://github.com/NixOS/nixpkgs/commit/39502faec9ca1b56bbce91056debe591211978ac) | `` python311Packages.lmcloud: init at 0.4.35 ``                                   |
| [`093f5bcd`](https://github.com/NixOS/nixpkgs/commit/093f5bcda1f325adb590682860bfcac3cd7c7c61) | `` glauth: add myself as maintainer ``                                            |
| [`0dfcbed2`](https://github.com/NixOS/nixpkgs/commit/0dfcbed29d4ba623b5fb226ae3ea17770750463d) | `` python312Packages.trimesh: 4.0.8 -> 4.0.10 ``                                  |
| [`7574ea53`](https://github.com/NixOS/nixpkgs/commit/7574ea5310b9b41a6b13829b47498546afea9204) | `` python311Packages.aioswitcher: enable darwin build ``                          |
| [`9b95e75f`](https://github.com/NixOS/nixpkgs/commit/9b95e75fe6c84cd9d3dc9eec2e41ab07e3f811ff) | `` logseq: 0.10.4 -> 0.10.5 ``                                                    |
| [`1323e311`](https://github.com/NixOS/nixpkgs/commit/1323e3115da413467ac973018af640ee216cab82) | `` nixos/tests: fix ssh-audit under network-online dep fix ``                     |
| [`e7451cac`](https://github.com/NixOS/nixpkgs/commit/e7451cacf995ffc11e4441605e435b4c63c8e5f8) | `` nixos/tests: fix installer under network-online dep fix ``                     |
| [`843b3e7a`](https://github.com/NixOS/nixpkgs/commit/843b3e7aa982e4c24407aabf2537ef529561b465) | `` nixos/tests: fix guix under network-online dep fix ``                          |
| [`a8a9424e`](https://github.com/NixOS/nixpkgs/commit/a8a9424e4fc91dfc116e5f59df7e4c5f7dcb7dde) | `` nixos/tests: fix adguardhome under network-online dep fix ``                   |
| [`fe474ed6`](https://github.com/NixOS/nixpkgs/commit/fe474ed61a3436644828a9709e2db6ed006f92aa) | `` nixos: fix remaining services for network-online dep fix ``                    |
| [`1b514b3e`](https://github.com/NixOS/nixpkgs/commit/1b514b3e10319b2d596879467cb13efdc18d970f) | `` fix: rxe under network-online.target change [UNSURE IF CORRECT] ``             |
| [`c80398e5`](https://github.com/NixOS/nixpkgs/commit/c80398e5d2325c31a4a884b407607b34aa752abc) | `` nixos/ircd-hybrid: fix evaluation error ``                                     |
| [`6c5ab28f`](https://github.com/NixOS/nixpkgs/commit/6c5ab28fcee342254aa9c8704008e2f33dc0dde1) | `` nixos: fix a bunch of services missing dep on network-online.target ``         |
| [`b8da5d6a`](https://github.com/NixOS/nixpkgs/commit/b8da5d6a3c690909ea3721cded8b8bd0e8476e18) | `` nixos/tests: fix gitdaemon under network-online dep fix ``                     |
| [`174ffdcb`](https://github.com/NixOS/nixpkgs/commit/174ffdcbc4f0512b26053ed18b53af1661d9cf27) | `` nixos/tests: fix tayga under network-online dep fix ``                         |
| [`9b29e5eb`](https://github.com/NixOS/nixpkgs/commit/9b29e5eb7efc7327f2ba5cb44a98df4196fb8ce3) | `` nixos/tests: fix owncast under network-online dep fix [BROKEN] ``              |
| [`dbb2d3e2`](https://github.com/NixOS/nixpkgs/commit/dbb2d3e220915443caf65e347f525f2a6e6604c9) | `` nixos/tests: fix systemd-nspawm under network-online dep fix ``                |
| [`42cda3b3`](https://github.com/NixOS/nixpkgs/commit/42cda3b36b2d2b78de480e23132778bee6c7319b) | `` nixos/tests: fix upnp under network-online dep fix ``                          |
| [`5714c846`](https://github.com/NixOS/nixpkgs/commit/5714c8465a9ea0fb90b3ef8f0846c6ec01d3de5e) | `` nixos/tests: fix lemmy under network-online dep fix ``                         |
| [`426d5046`](https://github.com/NixOS/nixpkgs/commit/426d5046b586fa63a5f78d5879bec32acea2f7d4) | `` nixos/tests: fix babeld under network-online dep fix ``                        |
| [`0caf1a03`](https://github.com/NixOS/nixpkgs/commit/0caf1a0311fd462379fc5ad04f029bbb9d42bc69) | `` qt5ct: Fix homepage link ``                                                    |
| [`936602b8`](https://github.com/NixOS/nixpkgs/commit/936602b87313eb90840ecc71f4a68dc548b644f5) | `` lapce: add meta.mainProgram ``                                                 |
| [`3f074f7b`](https://github.com/NixOS/nixpkgs/commit/3f074f7b9f8f8454d4058e362ef5b20e86641903) | `` kubernetes-helmPlugins.helm-diff: 3.8.1 -> 3.9.2 ``                            |
| [`f17bb90a`](https://github.com/NixOS/nixpkgs/commit/f17bb90abf062e9e1ca6c407c4baf1fda23102b1) | `` phpPackages.castor: 0.10.0 -> 0.11.1 ``                                        |
| [`0d7a0262`](https://github.com/NixOS/nixpkgs/commit/0d7a026204a1289ed15ffb347e757663faae9175) | `` phpExtensions.spx: 0.4.14 -> 0.4.15 ``                                         |
| [`ab0e6f9c`](https://github.com/NixOS/nixpkgs/commit/ab0e6f9c2cd1915cb0218f2e6fb2faa709cc77da) | `` crowdin-cli: 3.16.0 -> 3.16.1 ``                                               |
| [`f3e17f3b`](https://github.com/NixOS/nixpkgs/commit/f3e17f3b0c7515f9e5b20d0f9cc456e20fe0d047) | `` python311Packages.telegram-text: drop support for python 3.7 ``                |
| [`b1c1b33b`](https://github.com/NixOS/nixpkgs/commit/b1c1b33bf15303350db0e04ea9939bc947d59962) | `` python311Packages.asyncclick: 8.1.3.2 -> 8.1.7.1 ``                            |
| [`0b685d21`](https://github.com/NixOS/nixpkgs/commit/0b685d216ec1ba73555eba79f4c6aadddab6b4c8) | `` terrapin-scanner: 1.1.2 -> 1.1.3 ``                                            |
| [`75dee6f1`](https://github.com/NixOS/nixpkgs/commit/75dee6f146966d38084ad9732e3d2b7327e50c8a) | `` python311Packages.pyduotecno: 2024.1.1 -> 2024.1.2 ``                          |
| [`8f0e83be`](https://github.com/NixOS/nixpkgs/commit/8f0e83be499f3bac67efac9575159b87b1200ec9) | `` python311Packages.msoffcrypto-tool: 5.2.0 -> 5.3.1 ``                          |
| [`71129650`](https://github.com/NixOS/nixpkgs/commit/7112965044297a8acd7960a6c07915543324a828) | `` dnsperf: 2.13.1 -> 2.14.0 ``                                                   |
| [`ac31d424`](https://github.com/NixOS/nixpkgs/commit/ac31d42461f97f71703f3fe5b36a03a653969bdd) | `` python311Packages.dvc: add hdfs support ``                                     |
| [`08de99e0`](https://github.com/NixOS/nixpkgs/commit/08de99e0e222310e002c22485498fd3b34fe0e78) | `` python311Packages.dvc-hdfs: init at 3.0.0 ``                                   |
| [`7995cae3`](https://github.com/NixOS/nixpkgs/commit/7995cae3ad60e3d6931283d650d7f43d31aaa5c7) | `` circt: 1.61.0 -> 1.62.0 ``                                                     |
| [`938e217b`](https://github.com/NixOS/nixpkgs/commit/938e217b766898a1695831af9bc854b799e65df5) | `` python311Packages.dvc: add gdrive support ``                                   |
| [`fec956a7`](https://github.com/NixOS/nixpkgs/commit/fec956a70c7084497a7c6a0503661417c43ada89) | `` python311Packages.dvc-gdrive: init at 3.0.1 ``                                 |
| [`65e18256`](https://github.com/NixOS/nixpkgs/commit/65e182561bb6cf315047cdddd95cc20990663dc4) | `` python311Packages.pydrive2: set build system ``                                |
| [`1b699df0`](https://github.com/NixOS/nixpkgs/commit/1b699df0595368b5801b7591d2c06736fe67389f) | `` python311Packages.dvc: disable on unsupported Python releases ``               |
| [`f0af1613`](https://github.com/NixOS/nixpkgs/commit/f0af16131eadfe395985b6284797ce801fba3281) | `` python311Packages.dvc: 3.40.0 -> 3.40.1 ``                                     |
| [`fc76c16c`](https://github.com/NixOS/nixpkgs/commit/fc76c16c7869f527004a33ded9d6fd714cd25990) | `` clash-geoip: 20231212 -> 20240112 ``                                           |
| [`0074fb0f`](https://github.com/NixOS/nixpkgs/commit/0074fb0f4747ee4a8981edbcd5123385fcd2061b) | `` python311Packages.python-tado: add changelog to meta ``                        |
| [`2fb4dce9`](https://github.com/NixOS/nixpkgs/commit/2fb4dce9b56af6942d073640477e676a798e1003) | `` python311Packages.python-tado: remove comment ``                               |
| [`c45beedc`](https://github.com/NixOS/nixpkgs/commit/c45beedcf1df2b0073220b5afb7bc3eb42d731b9) | `` python311Packages.aioswitcher: refactor ``                                     |
| [`5ea1493a`](https://github.com/NixOS/nixpkgs/commit/5ea1493afdb5838f6f58e9c4715a324f8c62e7a0) | `` python311Packages.aioswitcher: 3.4.1 -> 3.4.2 ``                               |
| [`fa63ccce`](https://github.com/NixOS/nixpkgs/commit/fa63ccce212167d22d572f0f11a99f5f1685e875) | `` python311Packages.bthome-ble: 3.4.1 -> 3.5.0 ``                                |
| [`40b5d606`](https://github.com/NixOS/nixpkgs/commit/40b5d606bcb732fb024b1373dc54b934e227f915) | `` checkov: 3.1.66 -> 3.1.67 ``                                                   |
| [`2eb556c0`](https://github.com/NixOS/nixpkgs/commit/2eb556c0377bf599153b68cebe529f7b6213350b) | `` python311Packages.pytest-ansible: 24.1.1 -> 24.1.2 ``                          |
| [`a59134f9`](https://github.com/NixOS/nixpkgs/commit/a59134f91cd12bba6de98f3f8ade0e9a932ae90c) | `` python311Packages.python-tado: 0.17.3 -> 0.17.4 ``                             |
| [`1f51b36f`](https://github.com/NixOS/nixpkgs/commit/1f51b36fbac87f6e20ebe474e66f31952463a07f) | `` python311Packages.litellm: 1.17.0 -> 1.18.3 ``                                 |
| [`ff7cac1a`](https://github.com/NixOS/nixpkgs/commit/ff7cac1ac9d6aa011321717bc16d08ff4c7d3091) | `` netcat: correctly set mainProgram ``                                           |
| [`abeb90a3`](https://github.com/NixOS/nixpkgs/commit/abeb90a37b4f77876e1fdf8edc9cfeae0da5ceb9) | `` apacheHttpdPackages.php: 8.2.14 -> 8.2.15 ``                                   |
| [`ed36e5cc`](https://github.com/NixOS/nixpkgs/commit/ed36e5cc8cfbe943bb27feee681ae166311f4d4f) | `` itk: patch to unbreak with GCC13 ``                                            |
| [`b4cfeeb2`](https://github.com/NixOS/nixpkgs/commit/b4cfeeb20d9efbf9343ce88a57dbb78045ae2bbf) | `` python311Packages.telegram-text: 0.1.2 -> 0.2.0 ``                             |
| [`959e8a24`](https://github.com/NixOS/nixpkgs/commit/959e8a2428503f2a6b0928e626d7955627a90ac6) | `` brave: 1.61.114 -> 1.61.120 ``                                                 |
| [`e4e1973b`](https://github.com/NixOS/nixpkgs/commit/e4e1973b0573003d5f315ccd52e09786b14dbd73) | `` govc: 0.34.1 -> 0.34.2 ``                                                      |
| [`e5aef59b`](https://github.com/NixOS/nixpkgs/commit/e5aef59b814053e9750762e744387289dc1e1842) | `` Revert "top-level: use callPackages where inheriting packages" ``              |
| [`02da7261`](https://github.com/NixOS/nixpkgs/commit/02da7261b092e478e0e131f6fce984a3561ff247) | `` nuclei: 3.1.5 -> 3.1.6 ``                                                      |
| [`2f08cdc9`](https://github.com/NixOS/nixpkgs/commit/2f08cdc9275fa3ef13303a34d3540bf845641bf7) | `` alacritty-theme: unstable-2023-12-28 -> unstable-2024-01-15 ``                 |
| [`8928bbc4`](https://github.com/NixOS/nixpkgs/commit/8928bbc4f667720cb02e9bee2546ce48afa558fe) | `` rsonpath: 0.8.4 -> 0.8.6 ``                                                    |
| [`d32bb111`](https://github.com/NixOS/nixpkgs/commit/d32bb1112910e08ed4f0b56550ba16fc3208f8f5) | `` nixos/suwayomi-server: add release note ``                                     |
| [`279057b7`](https://github.com/NixOS/nixpkgs/commit/279057b7791a051f520ff0e78aab001333bb1626) | `` nixos/suwayomi-server: add nixos tests ``                                      |
| [`4133bb1b`](https://github.com/NixOS/nixpkgs/commit/4133bb1bb0824e59a35b349c7be9f4994aaa30c1) | `` nixos/suwayomi-server: init at 0.7.0 ``                                        |
| [`c413d90a`](https://github.com/NixOS/nixpkgs/commit/c413d90a111bd42e94b8a28bf17463a73f979502) | `` mpvScripts.blacklistExtensions: unstable-2023-12-18 -> unstable-2024-01-11 ``  |
| [`c11401bf`](https://github.com/NixOS/nixpkgs/commit/c11401bf4bf324a962190e3b13c0fc8154382322) | `` nixos/tests: fix trafficserver under network-online dep fix ``                 |
| [`f25957bb`](https://github.com/NixOS/nixpkgs/commit/f25957bb58b833cdeadd78269ef7e5e33d793310) | `` nixos/tests: fix 3proxy under network-online dep fix ``                        |
| [`83ba37ca`](https://github.com/NixOS/nixpkgs/commit/83ba37ca2d566eb9c4748cd93e79d6838bb34147) | `` nixos/tests: fix ulogd under network-online dep fix ``                         |