### PR TITLE
chore(flake/pre-commit): `9d3d7e18` -> `f56597d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -72,16 +72,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -101,11 +101,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703939133,
-        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
+        "lastModified": 1705757126,
+        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
+        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                      |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`1e702924`](https://github.com/cachix/pre-commit-hooks.nix/commit/1e702924c524d782ddaf18551a0900eccaf6e804) | `` fix: add/fix all the missing hooks, for real this time ``                 |
| [`05a6b4ce`](https://github.com/cachix/pre-commit-hooks.nix/commit/05a6b4ceef7f50d38c8295cad1c42deb06fef9d9) | `` feat: add check to ensure all hooks evaluate ``                           |
| [`fb4b6d03`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb4b6d03418ddf4dafbca01a1148e62d7a412bef) | `` fix(phpstan): disable lockfile validation ``                              |
| [`1d3eac11`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d3eac111dcf0dab2f9e4e6884c38234c96d8957) | `` fix(headache): avoid meta.mainProgram as it may not be set ``             |
| [`2c6c9d0f`](https://github.com/cachix/pre-commit-hooks.nix/commit/2c6c9d0fb9688e65520c7b56e973219172ce7ef0) | `` fix: use opentofu instead of terraform ``                                 |
| [`0b6fdb09`](https://github.com/cachix/pre-commit-hooks.nix/commit/0b6fdb0941e4dc283ff0e79e2d0aea74d713f2fc) | `` chore: update to nixos 23.11 ``                                           |
| [`33676735`](https://github.com/cachix/pre-commit-hooks.nix/commit/3367673535a9a68fa244c9f74679df080db3a5ae) | `` fix: fix up tools indirections, ensure the used tools actually exist ``   |
| [`59ed918b`](https://github.com/cachix/pre-commit-hooks.nix/commit/59ed918be7dfa25c489be21c57b7ea707f8023eb) | `` doc: fix readme for clang-format ``                                       |
| [`e4f7f070`](https://github.com/cachix/pre-commit-hooks.nix/commit/e4f7f070353728a823435aee17362128c1234967) | `` hooks: init cmake-format ``                                               |
| [`b46eab58`](https://github.com/cachix/pre-commit-hooks.nix/commit/b46eab585ea06f8f4980844f1b65aca7606ac15d) | `` hooks: unify pkgs -> tools ``                                             |
| [`02a45958`](https://github.com/cachix/pre-commit-hooks.nix/commit/02a459585885f57c3fd93bb4e0b9b573a62a1ee5) | `` Add args to prettier hook ``                                              |
| [`b568e6d3`](https://github.com/cachix/pre-commit-hooks.nix/commit/b568e6d3b8866f1256977fa49fefd12c4a806e86) | `` typos: unset pass_filenames ``                                            |
| [`35ba4e74`](https://github.com/cachix/pre-commit-hooks.nix/commit/35ba4e74d7ad7f3475a1484f3b993ff7a3336aef) | `` fix(stylua): add --respect-ignores flag ``                                |
| [`fbc317bf`](https://github.com/cachix/pre-commit-hooks.nix/commit/fbc317bff97af4dc4c9b98b92c1679c125473300) | `` hooks: flake8: add settings to extend the ignore list ``                  |
| [`911536a7`](https://github.com/cachix/pre-commit-hooks.nix/commit/911536a7bae59e7dd9169133d4eaf25d97d6c83b) | `` hooks: sort hooks alphabetically ``                                       |
| [`4cb6caa8`](https://github.com/cachix/pre-commit-hooks.nix/commit/4cb6caa8db49fc54de99592362c0d63958bcc12c) | `` hooks: sort settings alphabetically ``                                    |
| [`132ffd57`](https://github.com/cachix/pre-commit-hooks.nix/commit/132ffd57209171cdca31916f47cfebe7584cdcad) | `` doc: improve README.md ``                                                 |
| [`a44c73ba`](https://github.com/cachix/pre-commit-hooks.nix/commit/a44c73ba3e41ed048363c6aff972185a9c7b641e) | `` add cljfmt ``                                                             |
| [`1a76afaf`](https://github.com/cachix/pre-commit-hooks.nix/commit/1a76afaf33ac9b1089a153ba1b3ff8cf5c8f918c) | `` fix(modules/hooks): 'settings.typos.exclude' implies '--force-exclude' `` |