### PR TITLE
chore(flake/nixpkgs): `b4ee3c3c` -> `a4b6cee9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705692095,
-        "narHash": "sha256-iJazHf0FQjuIplTEvDHMkByxQD1kyCp4Cm78krkf3N8=",
+        "lastModified": 1746279357,
+        "narHash": "sha256-oBuu7hOtoqj3BbHp9H/8n8htBt9pMCDDRgrhA6yy0i8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4ee3c3cc4b63315702e09858f6b517bdd249b3f",
+        "rev": "a4b6cee9ab63822643e108f67da016aa800ea099",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`b302633d`](https://github.com/NixOS/nixpkgs/commit/b302633dbabdadc8dcf012cb2b21682ec8c28641) | `` python3Packages.neoteroi-mkdocs: fix tests on sandboxed darwin ``                       |
| [`654aadff`](https://github.com/NixOS/nixpkgs/commit/654aadff7246cc776294c40e001f12774ce1afe7) | `` cargo-seek: init at 0.1.0 ``                                                            |
| [`b20d91a4`](https://github.com/NixOS/nixpkgs/commit/b20d91a4898e7b5ab38fe546a88b098dbc0ec735) | `` pytyhon3Packages.essentials-openapi: fix tests on sandboxed darwin ``                   |
| [`d4a9346f`](https://github.com/NixOS/nixpkgs/commit/d4a9346f0e35e25313d33bacef500082b15142cc) | `` optinix: fix build ``                                                                   |
| [`f92c8fa9`](https://github.com/NixOS/nixpkgs/commit/f92c8fa9dcbac039cb3ba2e39401de82b5bf900e) | `` opencolorio_1: use gitMinimal ``                                                        |
| [`f1d239c8`](https://github.com/NixOS/nixpkgs/commit/f1d239c8859a4cf45ce549e88c4301977adc44a5) | `` opencolorio_1: modernize, add maintainer ``                                             |
| [`161da110`](https://github.com/NixOS/nixpkgs/commit/161da1104c92bd9b37409fab6d1cca740ca6acbe) | `` python312Packages.uv-dynamic-versioning: 0.8.0 -> 0.8.2 ``                              |
| [`fbd49ee8`](https://github.com/NixOS/nixpkgs/commit/fbd49ee83e956de389edd9568340b5ad96295e1a) | `` ratman: fix src hash ``                                                                 |
| [`52afe88d`](https://github.com/NixOS/nixpkgs/commit/52afe88d7068ba500ec23e35bac172d353e9a2b5) | `` kompute: unbreak by patching vulkan 1.4 support ``                                      |
| [`58effd4f`](https://github.com/NixOS/nixpkgs/commit/58effd4f00787f053d3040167382ebb9cd46e43f) | `` degate: unbreak by pinning boost ``                                                     |
| [`92a214b2`](https://github.com/NixOS/nixpkgs/commit/92a214b27304a2a8058d0385c6c408d907cc3c6d) | `` python3Packages.jupyter-server-ydoc: 2.0.1 -> 2.0.2 ``                                  |
| [`58dc90c9`](https://github.com/NixOS/nixpkgs/commit/58dc90c9f296d5a467cb0330d25635d4aced33e4) | `` maintainers: add ik-nz ``                                                               |
| [`556f9218`](https://github.com/NixOS/nixpkgs/commit/556f921837d67ea37b04a7f93ab3940c84ca61c6) | `` gdal: fix build ``                                                                      |
| [`0aa989ed`](https://github.com/NixOS/nixpkgs/commit/0aa989eda7fadeac3be894ac79c47338de03f9a4) | `` python3Packages.yalexs-ble: 2.6.0 -> 3.0.0 ``                                           |
| [`b526c6ef`](https://github.com/NixOS/nixpkgs/commit/b526c6ef88a3977857cf55c58d1339af95760f51) | `` artisan: 3.1.2 -> 3.1.4 ``                                                              |
| [`42190cb7`](https://github.com/NixOS/nixpkgs/commit/42190cb7a79177c04ec84d858d0e1e5f6c4e761e) | `` artisan: add updateScript ``                                                            |
| [`eaead951`](https://github.com/NixOS/nixpkgs/commit/eaead951be1c4fcc79b91a68bd009e50a0fbc3ca) | `` just-lsp: 0.2.0 -> 0.2.1 ``                                                             |
| [`041f5e02`](https://github.com/NixOS/nixpkgs/commit/041f5e02ff9964cc535b7aee0c4a620ed608e456) | `` python312Packages.mizani: 0.13.4 -> 0.13.5 ``                                           |
| [`848fcac1`](https://github.com/NixOS/nixpkgs/commit/848fcac122e4eaa29bf8d7939bcb8b8e4473dcd7) | `` mythtv: fix src hash ``                                                                 |
| [`a3980c78`](https://github.com/NixOS/nixpkgs/commit/a3980c78290d0bc6fae480c915f25cf411be66c1) | `` mythtv: prefer tag rather than rev for fetchFromGitHub ``                               |
| [`f4186aed`](https://github.com/NixOS/nixpkgs/commit/f4186aed0e2f1875a12c6545a3437c6a2d5afdd2) | `` python3Packages.docling-core: 2.28.0 -> 2.29.0 ``                                       |
| [`40ffa623`](https://github.com/NixOS/nixpkgs/commit/40ffa62369b5c1db4d1de8739527a21386b1121c) | `` clusternet: downgrade go version to fix build ``                                        |
| [`80399723`](https://github.com/NixOS/nixpkgs/commit/80399723929a1ed65ac407ccb4e8d0ffcc198e32) | `` python3Packages.sagemaker-core: 1.0.29 -> 1.0.31 ``                                     |
| [`49c08e3c`](https://github.com/NixOS/nixpkgs/commit/49c08e3c0d48e3a9caf2a4d0bc5859ad8d2ce49c) | `` lazygit: 0.49.0 -> 0.50.0 ``                                                            |
| [`79caba80`](https://github.com/NixOS/nixpkgs/commit/79caba80c050ae4cfb71b6898db6c56ae0d5b506) | `` action-validator: 0.6.0 -> 0.6.0-unstable-2025-02-16 ``                                 |
| [`5a2f8889`](https://github.com/NixOS/nixpkgs/commit/5a2f8889e02634cdcb8ac5b75d6d655bf0bfd10c) | `` libchop: drop ``                                                                        |
| [`08b2bab3`](https://github.com/NixOS/nixpkgs/commit/08b2bab3fd018e190b3955bc95fe6912db652387) | `` nix-converter: init at 0-unstable-2025-04-14 ``                                         |
| [`8ce4abb1`](https://github.com/NixOS/nixpkgs/commit/8ce4abb100ed8140bc79d0be74bc4ad7fc3a73d6) | `` gmni: drop ``                                                                           |
| [`e0541f42`](https://github.com/NixOS/nixpkgs/commit/e0541f42abdebc02d5b91f684218430c44a3f46b) | `` fastfetch: remove unused cmake options ``                                               |
| [`2c1a3811`](https://github.com/NixOS/nixpkgs/commit/2c1a3811e47695e6cbb39b1f46a4c77a2c46d0c8) | `` fastfetch: refactor dependencies more ``                                                |
| [`ec8b25b6`](https://github.com/NixOS/nixpkgs/commit/ec8b25b652947c7caf661503c18f7a3558e18c2a) | `` python313Packages.hieroglyph: fix build failure ``                                      |
| [`429c338e`](https://github.com/NixOS/nixpkgs/commit/429c338e1585c6f7af1076c3cd3825b2a4a2e1a3) | `` terraform-providers: special case for aws to use go123 ``                               |
| [`d432c233`](https://github.com/NixOS/nixpkgs/commit/d432c233d260183b80703a63051237662b989416) | `` qpid-cpp: unbreak by pinning boost ``                                                   |
| [`a8835c5d`](https://github.com/NixOS/nixpkgs/commit/a8835c5d849a6622a1be05e974761a04d20497e8) | `` intel-media-driver: 24.4.4 -> 25.1.4 ``                                                 |
| [`84a4b1ba`](https://github.com/NixOS/nixpkgs/commit/84a4b1ba3b3b23e400ab7a48f40bcb028537618e) | `` gersemi: 0.19.2 -> 0.19.3 ``                                                            |
| [`a4c36799`](https://github.com/NixOS/nixpkgs/commit/a4c367999c708a45e47df66eb033dbc1a454af00) | `` grap: unbreak by pinning boost ``                                                       |
| [`1356199c`](https://github.com/NixOS/nixpkgs/commit/1356199cd36fee288f24ebc32ffc011bf1e9fd4b) | `` zegrapher: unbreak by pinning boost ``                                                  |
| [`cf60bcfd`](https://github.com/NixOS/nixpkgs/commit/cf60bcfd4c891caed37bb53cc247a50a0e152f41) | `` python312Packages.pymilvus: 2.5.7 -> 2.5.8 ``                                           |
| [`0010ccd2`](https://github.com/NixOS/nixpkgs/commit/0010ccd2b594c17bda5769c77a3a421f8a662fc9) | `` terragrunt: 0.77.22 -> 0.78.0 ``                                                        |
| [`640193fb`](https://github.com/NixOS/nixpkgs/commit/640193fbb308025f906fc0e19343e16fd6d0dd80) | `` python3Packages.h5io: 0.2.1 -> 0.2.5 ``                                                 |
| [`7c4e6bcf`](https://github.com/NixOS/nixpkgs/commit/7c4e6bcf317100a8efb95764f8b21464b36cd61f) | `` python312Packages.mizani: 0.13.3 -> 0.13.4 ``                                           |
| [`cb9d72cd`](https://github.com/NixOS/nixpkgs/commit/cb9d72cd420d92db89144999679b4e2d3bf84c0d) | `` domination: 1.3.3 -> 1.3.4 ``                                                           |
| [`b78b6aa8`](https://github.com/NixOS/nixpkgs/commit/b78b6aa8b11468c9c68c99bac19baaac0c9127f7) | `` pantheon.xdg-desktop-portal-pantheon: 8.0.0 -> 8.0.1 ``                                 |
| [`6dd6b211`](https://github.com/NixOS/nixpkgs/commit/6dd6b211280417d6c983854437ec551dfaab914e) | `` drawpile: switch to qt6 ``                                                              |
| [`9f52e7ae`](https://github.com/NixOS/nixpkgs/commit/9f52e7ae3ba6d453da169fc224b3e07a58f36a05) | `` act: 0.2.76 -> 0.2.77 ``                                                                |
| [`bb117f1e`](https://github.com/NixOS/nixpkgs/commit/bb117f1e040d4d7119f52e70c2fcefa114785923) | `` flexget: 3.15.37 -> 3.15.38 ``                                                          |
| [`554b3ffb`](https://github.com/NixOS/nixpkgs/commit/554b3ffbf1dfa196ae7232c5fa6fc4469d18d992) | `` phpunit: 12.1.3 -> 12.1.4 ``                                                            |
| [`4cad2bd1`](https://github.com/NixOS/nixpkgs/commit/4cad2bd16f02b321290f907c7fdd11575acb0a9f) | `` ISSUE_TEMPLATE: Create option for packages without a Hydra build status (#400751) ``    |
| [`22bf0a21`](https://github.com/NixOS/nixpkgs/commit/22bf0a213faa7d0308fc006447d543cfb71ad12a) | `` flitter: 1.1.1 -> 1.1.3 ``                                                              |
| [`9af52ca2`](https://github.com/NixOS/nixpkgs/commit/9af52ca2475674bed3b3aca5962546613dfdf892) | `` beeper: 4.0.640 -> 4.0.661 ``                                                           |
| [`66eff6f8`](https://github.com/NixOS/nixpkgs/commit/66eff6f896e29f981e8c4f9845efeefca5b5f5e9) | `` pantheon.switchboard-plug-about: 8.2.0 -> 8.2.1 ``                                      |
| [`7742cfd0`](https://github.com/NixOS/nixpkgs/commit/7742cfd0633ae6a820e3fa5840fa2f10d547d30c) | `` n2: unstable-2023-10-10 -> unstable-2025-03-14 ``                                       |
| [`1dd65f83`](https://github.com/NixOS/nixpkgs/commit/1dd65f83d3d4504c36416cd79bc117d2a2ea9424) | `` ollama: 0.6.6 -> 0.6.7 ``                                                               |
| [`fc077d0d`](https://github.com/NixOS/nixpkgs/commit/fc077d0d1fa3401d9d65cbca38215e6dddc87135) | `` python3Packages.google-cloud-bigtable: 2.30.0 -> 2.30.1 ``                              |
| [`e6b21afb`](https://github.com/NixOS/nixpkgs/commit/e6b21afbba674d5584f985a00cdebe7405692621) | `` cobang: 1.6.1 -> 1.6.2 ``                                                               |
| [`43e519b0`](https://github.com/NixOS/nixpkgs/commit/43e519b0e0f46b7d8f61bf57c4bbb28f9f9a9d70) | `` skyemu: init at 3.0.0 ``                                                                |
| [`a719fb17`](https://github.com/NixOS/nixpkgs/commit/a719fb17be95abe2af0705351d46ec070a2fa9d4) | `` python313Packages.pystemd: modernize ``                                                 |
| [`f0936d4e`](https://github.com/NixOS/nixpkgs/commit/f0936d4e975bc1aa05c831c567d968a92b858b8a) | `` {kubernetes,kubectl}: 1.32.3 -> 1.33.0 ``                                               |
| [`14e52aca`](https://github.com/NixOS/nixpkgs/commit/14e52aca5d68be092249fee3b9d5ae8533b05dde) | `` python3Packages.oslo-utils: disable flaky test ``                                       |
| [`2a5e38b0`](https://github.com/NixOS/nixpkgs/commit/2a5e38b022e54ee7e1849a22eb897b048f379c91) | `` kubernetes-helmPlugins.helm-secrets: 4.6.3 -> 4.6.4 ``                                  |
| [`e5ab85fe`](https://github.com/NixOS/nixpkgs/commit/e5ab85feaa5e54e4aa7b583512ab275cbd37dfb9) | `` mullvad-browser: 14.5 -> 14.5.1 ``                                                      |
| [`2c197205`](https://github.com/NixOS/nixpkgs/commit/2c19720539174df9703d1328e20a139e7dacd9d6) | `` tor-browser: 14.5 -> 14.5.1 ``                                                          |
| [`010bb2f8`](https://github.com/NixOS/nixpkgs/commit/010bb2f82772921b140277919611d04cef7ee341) | `` python3Package.parfive: build from source ``                                            |
| [`ba4935b9`](https://github.com/NixOS/nixpkgs/commit/ba4935b9cb914b0697147ffd71a376ea37eb7a36) | `` python3Packages.aiohttp-swagger: remove tests ``                                        |
| [`914592a8`](https://github.com/NixOS/nixpkgs/commit/914592a83e2bdf11333301e191c64edcc9582207) | `` python3Packages.aiohttp-swagger: modernize ``                                           |
| [`840a221d`](https://github.com/NixOS/nixpkgs/commit/840a221d30ad127e70fd159781553b19ac2ad5d8) | `` python3Packages.py-stringmatching: fixes ``                                             |
| [`eb5312b5`](https://github.com/NixOS/nixpkgs/commit/eb5312b58319d7a5041cc2fa6f2c0146168d5e9e) | `` OWNERS: add owners for teleport files ``                                                |
| [`18138189`](https://github.com/NixOS/nixpkgs/commit/18138189b23cda54a59d894824dfb66f160bd26b) | `` nixos/cook-cli: fix missing module-list.nix entry ``                                    |
| [`83df0ca1`](https://github.com/NixOS/nixpkgs/commit/83df0ca14badcc20fa745da208d63815e1bec8cb) | `` wgsl-analyzer: 0.9.8 -> 2025-04-04 ``                                                   |
| [`1044c1da`](https://github.com/NixOS/nixpkgs/commit/1044c1da93e689341e0eba244e7c9d0499fd25d8) | `` linux-libre.scripts: 19746 -> 19769 ``                                                  |
| [`68d4d5da`](https://github.com/NixOS/nixpkgs/commit/68d4d5da4fc968d26042eb90be53630065d3333d) | `` mkvtoolnix: 91.0 -> 92.0 ``                                                             |
| [`26a0b9db`](https://github.com/NixOS/nixpkgs/commit/26a0b9dbd80f96f8deb1d71612da4b659c1fe2d7) | `` foot: 1.22.2 → 1.22.3 (#403568) ``                                                      |
| [`83247c0d`](https://github.com/NixOS/nixpkgs/commit/83247c0d415ace64066add427179c7e6878cf6b5) | `` .github/labeler.yml: add COSMIC topic ``                                                |
| [`0f3b5ca1`](https://github.com/NixOS/nixpkgs/commit/0f3b5ca11b8f38a59748dda652b5d34af59bdac0) | `` python3Packages.pyeclib: disable flaky memory usage test ``                             |
| [`d96d01d7`](https://github.com/NixOS/nixpkgs/commit/d96d01d7aa2d1193516e1382ce053ecee297027c) | `` python313Packages.pystemd: unbreak ``                                                   |
| [`ef4f4bc8`](https://github.com/NixOS/nixpkgs/commit/ef4f4bc8070c96356769c5b0694cc5be3633cdda) | `` vimPlugins.blink-cmp: 1.1.1 -> 1.2.0 ``                                                 |
| [`4a0173a7`](https://github.com/NixOS/nixpkgs/commit/4a0173a7368905ceb5ebf04d33712039fc127601) | `` vimPlugins.peek-nvim: fix JS build dependency handling ``                               |
| [`c07fab49`](https://github.com/NixOS/nixpkgs/commit/c07fab49b1b46e7f5a939dced7128e509d010f28) | `` nb-cli: expand pythonImportsCheck ``                                                    |
| [`2352b85c`](https://github.com/NixOS/nixpkgs/commit/2352b85c437736a0c5841c27f90911e15400bc35) | `` nb-cli: unbreak by relaxin watchfiles ``                                                |
| [`7d14fdca`](https://github.com/NixOS/nixpkgs/commit/7d14fdcaf941a142632256e0738a738c4fd07500) | `` python312Packages.ypy-websocket: disable failing test due to unmaintained dependency `` |
| [`29f4c3cf`](https://github.com/NixOS/nixpkgs/commit/29f4c3cf9460428908a4904b3510b5ff6c026e82) | `` kaggle: unbreak ``                                                                      |