### PR TITLE
chore(flake/pre-commit): `f56597d5` -> `dcf50727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,42 +70,22 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": [
-          "flake-utils"
-        ],
         "gitignore": [
           "gitignore"
         ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1705757126,
-        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`b34e865b`](https://github.com/cachix/git-hooks.nix/commit/b34e865b1b69361ed66a3b6f39545cc336ea09af) | `` vale: fix outdated configuration variable name ``                                         |
| [`215e290e`](https://github.com/cachix/git-hooks.nix/commit/215e290e965202a4094c301231e31013e2a9aceb) | `` chore(deps): update cachix/install-nix-action action to v31 ``                            |
| [`504a8b39`](https://github.com/cachix/git-hooks.nix/commit/504a8b396702f8ae94219c0b050f8664353dcb43) | `` chore(deps): update cachix/cachix-action action to v16 ``                                 |
| [`f4cdd2cc`](https://github.com/cachix/git-hooks.nix/commit/f4cdd2cc618f1ad3d8e4e43da36a120d55ee2b72) | `` Improve `configPath` docs ``                                                              |
| [`e2fcecd7`](https://github.com/cachix/git-hooks.nix/commit/e2fcecd7db11ee277dc9fd8c285ddfd2ae7840af) | `` Improve the error message when an existing config is found ``                             |
| [`d952b5be`](https://github.com/cachix/git-hooks.nix/commit/d952b5be9c76833413cd8e4dab74a6e89b3e3719) | `` Pass through all options in `run` ``                                                      |
| [`5af65eba`](https://github.com/cachix/git-hooks.nix/commit/5af65eba2b5d1a27111a3605dc06d59bed07aa86) | `` Use the correct path when unlinking the exising config ``                                 |
| [`10907c7f`](https://github.com/cachix/git-hooks.nix/commit/10907c7f1298610682d748e4476316d979d13455) | `` Remove extraneous check for git in PATH ``                                                |
| [`843e005b`](https://github.com/cachix/git-hooks.nix/commit/843e005b4877e80446c87788e362537891b063ff) | `` disable expensive julia tests ``                                                          |
| [`316f09cb`](https://github.com/cachix/git-hooks.nix/commit/316f09cb683baabd66d8b4a55c9b28d090005ff4) | `` docs: sort sections by name ``                                                            |
| [`fcea9160`](https://github.com/cachix/git-hooks.nix/commit/fcea91603f24a41113c1b9e4043510b1b96e10bb) | `` Revert "ci: use self-hosted runners" ``                                                   |
| [`61fa9623`](https://github.com/cachix/git-hooks.nix/commit/61fa9623cba72d8bde0b84e264725584602e8cf2) | `` ci: use self-hosted runners ``                                                            |
| [`75796622`](https://github.com/cachix/git-hooks.nix/commit/75796622e2775e624944ff08e74777c383d2b65d) | `` docs: add supported but non-mentioned hooks ``                                            |
| [`1b310e63`](https://github.com/cachix/git-hooks.nix/commit/1b310e63b6934f1231c47631fd6fe56214346c08) | `` docs: sort hook sections by name ``                                                       |
| [`69f02f04`](https://github.com/cachix/git-hooks.nix/commit/69f02f043e8ad95dd34eb988343daea3481112f1) | `` feat: add selene hook ``                                                                  |
| [`48ebf153`](https://github.com/cachix/git-hooks.nix/commit/48ebf1537f97ffb989c126530c58091e3b4b66d5) | `` fix(fourmolu): refer to its own settings ``                                               |
| [`3adca9e8`](https://github.com/cachix/git-hooks.nix/commit/3adca9e8ed94feefb52765a0645e65a8ced04c2c) | `` Exposes configPath to the run wrapper ``                                                  |
| [`741fee02`](https://github.com/cachix/git-hooks.nix/commit/741fee02daf336cbca92e2887fbfb6d36050d305) | `` feat: add proselint (#555) ``                                                             |
| [`c9d05edf`](https://github.com/cachix/git-hooks.nix/commit/c9d05edf105495791fd154dd6f4ca626bfee0d3d) | `` dev: drop shellcheck from our dev checks ``                                               |
| [`3234ee65`](https://github.com/cachix/git-hooks.nix/commit/3234ee65344afdeada9c97408ee310647b801e44) | `` Update modules/hooks.nix ``                                                               |
| [`9a456ab1`](https://github.com/cachix/git-hooks.nix/commit/9a456ab1a5a25788915e8a0ecaec35970f163bfb) | `` feat: add mdformat hook ``                                                                |
| [`d8bf272f`](https://github.com/cachix/git-hooks.nix/commit/d8bf272fdf5afb4efe9b45c6cebde91d5776422b) | `` feat: add dart format and dart analyze hook ``                                            |
| [`ba017b20`](https://github.com/cachix/git-hooks.nix/commit/ba017b20949d15ee5989e37cd283c9abf4ef39a5) | `` feat: add gitlint hook ``                                                                 |
| [`0dcaa895`](https://github.com/cachix/git-hooks.nix/commit/0dcaa8952727eedd9d140a61e68a46113dae1ae9) | `` feat: openapi-spec-validator ``                                                           |
| [`f2fcd043`](https://github.com/cachix/git-hooks.nix/commit/f2fcd0436f5ff0bceaaa1832edc5354bd830c55b) | `` Improve error message ``                                                                  |
| [`46930280`](https://github.com/cachix/git-hooks.nix/commit/46930280dc37703b7c28dfc4d4b12fa82f598852) | `` Run all validations and exit 1 if one of them failed ``                                   |
| [`4ec8f406`](https://github.com/cachix/git-hooks.nix/commit/4ec8f406ac9d59eaf79303a26192e780468289d4) | `` Print file path ``                                                                        |
| [`27cf82e6`](https://github.com/cachix/git-hooks.nix/commit/27cf82e6e0ead266e516715c2fa3c5823360d90b) | `` Add missing parenthesis ``                                                                |
| [`8b60f8b8`](https://github.com/cachix/git-hooks.nix/commit/8b60f8b8aae2ec80395df1f81148ca412c61792b) | `` Loop over all files that changed ``                                                       |
| [`18e58987`](https://github.com/cachix/git-hooks.nix/commit/18e5898730572dfcb17d22e56407b991e81d45ef) | `` Update file filter ``                                                                     |
| [`c2fbe2db`](https://github.com/cachix/git-hooks.nix/commit/c2fbe2dbf51f219020042f87e9fb81dcd0c0e927) | `` Look for changes on all files inside .circleci ``                                         |
| [`231e0ee0`](https://github.com/cachix/git-hooks.nix/commit/231e0ee07565895df670946642fd6ab3099b10da) | `` feat: Add CircleCI hook ``                                                                |
| [`324069d7`](https://github.com/cachix/git-hooks.nix/commit/324069d7531266ce3a3a49e3c199b2a739d5c5d2) | `` pretty-format-json: expose tool options in settings ``                                    |
| [`129cb475`](https://github.com/cachix/git-hooks.nix/commit/129cb475213bdb9bd6e34442aa77eaeebd4ad424) | `` yamlfmt: allow formatting during hook run ``                                              |
| [`9364dc02`](https://github.com/cachix/git-hooks.nix/commit/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17) | `` feat: Change `terraform-format` to support both Terraform and OpenTofu packages (#419) `` |
| [`b24ef710`](https://github.com/cachix/git-hooks.nix/commit/b24ef710754ce68f2aa56e594e4d36419944ea30) | `` check: set HOME to a tmp dir to avoid polluting the working dir ``                        |
| [`46171f0a`](https://github.com/cachix/git-hooks.nix/commit/46171f0a3611501c72e0380e399af1bbb891d8d5) | `` hooks: add note for flake-based projects using paths ``                                   |
| [`baf942ec`](https://github.com/cachix/git-hooks.nix/commit/baf942ec75b17c77f02413a96ad61426a896e18a) | `` hooks: add examples ``                                                                    |
| [`bad35860`](https://github.com/cachix/git-hooks.nix/commit/bad358603b4ac83bb48840cb310dcf4138bf3793) | `` hooks: allow strings for path-based options ``                                            |
| [`586b2df6`](https://github.com/cachix/git-hooks.nix/commit/586b2df6cb6f63947fefee7d12af4e8358cfdda4) | `` docs: add `trufflehog` entry ``                                                           |
| [`8dd173fe`](https://github.com/cachix/git-hooks.nix/commit/8dd173fea096445d8e61c342827bb4a223231778) | `` fix: add configFile option ``                                                             |
| [`ef1a5f9e`](https://github.com/cachix/git-hooks.nix/commit/ef1a5f9ec103334d1960852e943c5411828b9d75) | `` ci: limit concurrency ``                                                                  |
| [`0070c0b9`](https://github.com/cachix/git-hooks.nix/commit/0070c0b94a528fe745843b2a68e3a9ae5bbb2ecd) | `` ci: split stable and unstable tests ``                                                    |
| [`76a43622`](https://github.com/cachix/git-hooks.nix/commit/76a436220ae3fea161c7370c06efa1e55cbb1f00) | `` Remove nixpkgs-stable input ``                                                            |
| [`3e3ebb27`](https://github.com/cachix/git-hooks.nix/commit/3e3ebb2765e48344a3ab700fc25c125181eb8bcb) | `` chore(cabal2nix): stick to camelCase ``                                                   |
| [`03c878f8`](https://github.com/cachix/git-hooks.nix/commit/03c878f82e08d28345604895e84188e249b9ce21) | `` fix: biome write deprecation ``                                                           |
| [`96209c15`](https://github.com/cachix/git-hooks.nix/commit/96209c15446f3fa6985306fbb9034635cf69c1fc) | `` Throw a pretty error if the hooks cannot be sorted ``                                     |
| [`4d562428`](https://github.com/cachix/git-hooks.nix/commit/4d562428f8bfebae5504f6189acef68833a6450d) | `` Simplify internal `before`/`after` code ``                                                |
| [`3e7d7910`](https://github.com/cachix/git-hooks.nix/commit/3e7d791061be477b20a9d4e1f57872a51a392a57) | `` bugfix: remove before/after options from config json file ``                              |
| [`2c69d710`](https://github.com/cachix/git-hooks.nix/commit/2c69d710c20b8856e18d01fd4f6d265175167eec) | `` chore: add a default priority to `cabal2nix` which ensures it runs after `hpack` ``       |
| [`06d077bf`](https://github.com/cachix/git-hooks.nix/commit/06d077bf86c056451418ac209ec7819f6a2a2cfb) | `` feat(hook order): add before, after options to specify hooks order ``                     |
| [`ac756a3a`](https://github.com/cachix/git-hooks.nix/commit/ac756a3a8208a18e764f87016a04fc8212dcc275) | `` feat: add priority to hooks. ``                                                           |
| [`8a8d2b81`](https://github.com/cachix/git-hooks.nix/commit/8a8d2b81f465bb693c676a285f1ba93b4d3a8931) | `` make sure that clang-tools is in the same version across all platforms ``                 |
| [`be16516d`](https://github.com/cachix/git-hooks.nix/commit/be16516ddd761e03509849c2d037925f826740cc) | `` feat: add an option to cabal2nix hook for specifying output filename. ``                  |
| [`b6d9d72d`](https://github.com/cachix/git-hooks.nix/commit/b6d9d72d3dcedbe564a0c5ad47d311a0bc6a6563) | `` feat: support cargo/runtime dependencies ``                                               |
| [`f8333004`](https://github.com/cachix/git-hooks.nix/commit/f83330040d0530f1ddbbc1b0b1a1c707bd85a2de) | `` feat: make git package configurable and default to gitMinimal ``                          |
| [`d27273c4`](https://github.com/cachix/git-hooks.nix/commit/d27273c4adcafedea7f368b1f1ba291402518e37) | `` readme: Mention flake-parts ``                                                            |
| [`b87ed055`](https://github.com/cachix/git-hooks.nix/commit/b87ed055fb24db57ab528319d1e2026a6b8907d7) | `` feat(treefmt): add options to settings and disable cache by default ``                    |
| [`26f0d52b`](https://github.com/cachix/git-hooks.nix/commit/26f0d52b005bce294591c120585d6993c62cb8cb) | `` chore(deps): lock file maintenance ``                                                     |
| [`04db8c18`](https://github.com/cachix/git-hooks.nix/commit/04db8c18ca4667986514ef81dc93d88998e9438d) | `` fix: poetry option is not defined ``                                                      |
| [`92495abe`](https://github.com/cachix/git-hooks.nix/commit/92495abe55afe79f1f7b23a0b304d8dc3fa29740) | `` fix: poetry option is not defined ``                                                      |
| [`b3ff86fc`](https://github.com/cachix/git-hooks.nix/commit/b3ff86fcd0a1cd990dbec5b9efff5578e6202967) | `` fix: avoid use of deprecated stage names ``                                               |
| [`f187f18b`](https://github.com/cachix/git-hooks.nix/commit/f187f18bec64d13a0cac592fa2d8c6a579f1ac3d) | `` Spelling: Check *.org files ``                                                            |
| [`92e4fb63`](https://github.com/cachix/git-hooks.nix/commit/92e4fb63b9dd1acc4e9c0198eebc6cbbc8d0ad4a) | `` docs: fix defaults ``                                                                     |
| [`af52f533`](https://github.com/cachix/git-hooks.nix/commit/af52f533c96d6ccf706de85d47ea79c86210ec80) | `` fix(rustfmt): add cargoManifestPath back ``                                               |
| [`7e36b4c2`](https://github.com/cachix/git-hooks.nix/commit/7e36b4c2aba327e73cddd7ec833f51874f3bf5e5) | `` fix: add golines to tools.nix ``                                                          |
| [`e76201cb`](https://github.com/cachix/git-hooks.nix/commit/e76201cb5eb84bc613ef4276f7d0095978233a06) | `` hooks: fix rome and nixfmt migrations ``                                                  |
| [`eb74e0be`](https://github.com/cachix/git-hooks.nix/commit/eb74e0be24a11a1531b5b8659535580554d30b28) | `` typo ``                                                                                   |
| [`c93e347b`](https://github.com/cachix/git-hooks.nix/commit/c93e347b6ffdd98709a949faeb5480a8ccf11da0) | `` feat(run.nix): expose more ``                                                             |
| [`6a3d0eb6`](https://github.com/cachix/git-hooks.nix/commit/6a3d0eb6b64920b33683111bce68d1f4a9ef51dd) | `` statix: skip adding `--ignore` if empty ``                                                |
| [`1fe5afc7`](https://github.com/cachix/git-hooks.nix/commit/1fe5afc78489820f5586a9c90f91358a169604a7) | `` statix: fix broken list option `--ignore` ``                                              |
| [`6ce0397f`](https://github.com/cachix/git-hooks.nix/commit/6ce0397f4bd8af17e83639f7c561a64799fd81ae) | `` feat(rustfmt): add settings ``                                                            |
| [`7ee593e0`](https://github.com/cachix/git-hooks.nix/commit/7ee593e0d1dda9d0038f63db58360b7f891f5123) | `` feat(statix): add settings ``                                                             |
| [`1a1c7c6b`](https://github.com/cachix/git-hooks.nix/commit/1a1c7c6b618aed1602a609c184a948836b7bbc67) | `` add golines pre-commit hook ``                                                            |
| [`3b3c05c4`](https://github.com/cachix/git-hooks.nix/commit/3b3c05c4a011d6c9fedcce0a824fc6a570b149ad) | `` chore(deps): update cachix/install-nix-action action to v30 ``                            |
| [`9d2422b4`](https://github.com/cachix/git-hooks.nix/commit/9d2422b4cd86323236578c20fe76443462e7eaba) | `` Add extraArgs for clippy ``                                                               |
| [`9f73309f`](https://github.com/cachix/git-hooks.nix/commit/9f73309ff19bda94d6bcbe77dcd72c1c65a9f37d) | `` modules: pre-commit: make pkgs.buildEnv composable ``                                     |
| [`3ad0dd51`](https://github.com/cachix/git-hooks.nix/commit/3ad0dd517ff5e80610f892c75eb3ada3acd820bd) | `` chore(deps): update cachix/install-nix-action action to v29 ``                            |
| [`0ec644ce`](https://github.com/cachix/git-hooks.nix/commit/0ec644cee9abdf81ea1b3ce9303d59e6c9764b0b) | `` add trufflehog to tools ``                                                                |
| [`0b4048d9`](https://github.com/cachix/git-hooks.nix/commit/0b4048d9b7da3e1ded5d3e5fbc2e8250efd51d0e) | `` add working but unconfigurable trufflehog module ``                                       |
| [`b8fafdec`](https://github.com/cachix/git-hooks.nix/commit/b8fafdec45b0846ba970377a269322f33cd541a0) | `` modules/hooks.nix: restore alphabetical order ``                                          |
| [`bf798609`](https://github.com/cachix/git-hooks.nix/commit/bf798609c796fb8e9945c5b87dc014c9b7a3058d) | `` feat: update pre-commit.nix to be "run" customizable ``                                   |
| [`cbb1a986`](https://github.com/cachix/git-hooks.nix/commit/cbb1a986424bfb874eacc4d50e0374a647126efe) | `` nixfmt: deprecate `nixfmt` and redirect to `nixfmt-classic` or `nixfmt-rfc-style` ``      |
| [`334af94e`](https://github.com/cachix/git-hooks.nix/commit/334af94e9c4375784beedec943b8c94bfa474e44) | `` Add support for nixfmt-rfc-style ``                                                       |
| [`90999f96`](https://github.com/cachix/git-hooks.nix/commit/90999f9641e46184aedb797718d63eb68febe2f0) | `` alejandra: fix shell escape for file excludes ``                                          |
| [`55b98216`](https://github.com/cachix/git-hooks.nix/commit/55b98216505b209b09499cfa39b34a3d63bc9ca3) | `` feat: register gc root for the generated .pre-commit-config.yaml ``                       |
| [`c08fc07f`](https://github.com/cachix/git-hooks.nix/commit/c08fc07fee0184930287843b7d2e4ba36c858f0b) | `` docs: rename pre-commit-hooks.nix instances to git-hooks.nix ``                           |
| [`51605d94`](https://github.com/cachix/git-hooks.nix/commit/51605d94ce4c8741c45a7217f94a24f353bf8071) | `` fix(lua-ls): only fail if there are diagnostics ``                                        |
| [`515d252e`](https://github.com/cachix/git-hooks.nix/commit/515d252eb3c382e0ecc6c8158a6a75f191da3f2a) | `` fix: switch nixfmt to nixfmt-classic ``                                                   |
| [`bfef0ada`](https://github.com/cachix/git-hooks.nix/commit/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba) | `` chore: update renovate config ``                                                          |
| [`a98a24e4`](https://github.com/cachix/git-hooks.nix/commit/a98a24e48dddd9c0f2b351f7906df41e2f0c77ec) | `` chore: update renovate config ``                                                          |
| [`c2f6ace9`](https://github.com/cachix/git-hooks.nix/commit/c2f6ace9d7f9d583aa0f32eea1ed77f4359c7987) | `` feat: add terraform-validate hook ``                                                      |
| [`49b141a7`](https://github.com/cachix/git-hooks.nix/commit/49b141a7659d0c78cad85d75a5a2160604a121bb) | `` hook(shfmt): add `simplify` toggle to settings ``                                         |
| [`c22803ea`](https://github.com/cachix/git-hooks.nix/commit/c22803eaa20a9ae43e04354d1c83d2ae1862d5de) | `` fix: fixup args and exclude_types ``                                                      |
| [`d1948b48`](https://github.com/cachix/git-hooks.nix/commit/d1948b48c9857727f2c44eec85fa511714bc6e9c) | `` Added `args` and `exclude_types` to hook type ``                                          |
| [`54ac8605`](https://github.com/cachix/git-hooks.nix/commit/54ac86058e30d476ae0ff4c428d40a8c3eb2581e) | `` fix: change ruff format hook name ``                                                      |
| [`2d366523`](https://github.com/cachix/git-hooks.nix/commit/2d366523b68afee27c0ddb40cd0f46c7c51ef563) | `` docs: add ruff-format to python list ``                                                   |
| [`509f5059`](https://github.com/cachix/git-hooks.nix/commit/509f50596bd654cbf4c124589d3a608879978341) | `` feat: add ruff-format ``                                                                  |
| [`2c2eb0d4`](https://github.com/cachix/git-hooks.nix/commit/2c2eb0d42ef93f85d151a7ecff840cd78a7d9893) | `` Update Ruff check ``                                                                      |
| [`587776af`](https://github.com/cachix/git-hooks.nix/commit/587776afda8e6a57a8a8db9c2fe9cf11e3ecfc16) | `` Allow importing modules into the inner module system. ``                                  |
| [`11e7fbf7`](https://github.com/cachix/git-hooks.nix/commit/11e7fbf782eec015600836938006bd635791bf2c) | `` feat: add cabal-gild ``                                                                   |
| [`0f6f5fd8`](https://github.com/cachix/git-hooks.nix/commit/0f6f5fd8deb35b9213397af6d0512e8f7fe5752d) | `` chore: update to nixos 24.05 ``                                                           |
| [`8ee4af3f`](https://github.com/cachix/git-hooks.nix/commit/8ee4af3fd1a442d01cc0b9ccf4240347f595519c) | `` docs: clarify terraform-format ``                                                         |
| [`6283849b`](https://github.com/cachix/git-hooks.nix/commit/6283849b803cf115bc0bea4a69e456ced9def947) | `` fixed typstyle argument ``                                                                |
| [`324caa94`](https://github.com/cachix/git-hooks.nix/commit/324caa94a6596ad4ded781e54f8032ab6d46f590) | `` chore(deps): lock file maintenance ``                                                     |
| [`31b8b84b`](https://github.com/cachix/git-hooks.nix/commit/31b8b84b0ce9f517993e49afe4688a36b470e198) | `` dev: remove deprecated lib.mdDoc ``                                                       |
| [`6997a2e3`](https://github.com/cachix/git-hooks.nix/commit/6997a2e345cc90f65e0fb30571f089749a5a4263) | `` chore(deps): update cachix/install-nix-action action to v27 ``                            |
| [`66b68332`](https://github.com/cachix/git-hooks.nix/commit/66b68332893bedc1a1c05629cc4836cee21101e9) | `` chore(deps): update cachix/cachix-action action to v15 ``                                 |
| [`250a88b6`](https://github.com/cachix/git-hooks.nix/commit/250a88b62c3b629be27b07ccc28eaf81021a9e6c) | `` chore(deps): update actions/checkout action to v4 ``                                      |
| [`df3ac191`](https://github.com/cachix/git-hooks.nix/commit/df3ac1917f9fdf993a5b925cbde0428838831452) | `` dev: fix typo hook false positive ``                                                      |
| [`6e6b9257`](https://github.com/cachix/git-hooks.nix/commit/6e6b9257d9b90b4d5db1a11cff022c46d70eec2e) | `` fix typo in attribute ``                                                                  |
| [`62e46b44`](https://github.com/cachix/git-hooks.nix/commit/62e46b442d0c96ed57b02a28b7594376a03884b9) | `` check if typstyle exists ``                                                               |
| [`5ad3b469`](https://github.com/cachix/git-hooks.nix/commit/5ad3b46953786d3a56331533122f8f1cac14260c) | `` flake.lock: Update ``                                                                     |
| [`7d16e393`](https://github.com/cachix/git-hooks.nix/commit/7d16e39360278891ba80ce1660f2963972298250) | `` feat: fix reuse not found in flake check ``                                               |
| [`9a04830f`](https://github.com/cachix/git-hooks.nix/commit/9a04830f93ea80c9fc0bf4cf883a4fcf30d0944c) | `` fix: pyright has moved out of nodePackages ``                                             |
| [`21e0e90f`](https://github.com/cachix/git-hooks.nix/commit/21e0e90ff4d64f6aa47a8439d0b39e746fe2e7c3) | `` feat: add reuse ``                                                                        |
| [`6522d751`](https://github.com/cachix/git-hooks.nix/commit/6522d751c12a5c99a3c05cfcaef8d09849d730fc) | `` feat: add typstyle ``                                                                     |
| [`d74bff58`](https://github.com/cachix/git-hooks.nix/commit/d74bff580363f769289a4b4938d30555433b858f) | `` fix: update tools.nix to include yamlfmt ``                                               |
| [`e4eba37a`](https://github.com/cachix/git-hooks.nix/commit/e4eba37a68d50179ff5af1705a54d5fd508f7bd5) | `` feat: add yamlfmt ``                                                                      |
| [`10a15426`](https://github.com/cachix/git-hooks.nix/commit/10a15426814594c35507c1c122bc9a7a1f92a119) | `` Include hpack in the hpack dir output ``                                                  |
| [`cfac92f4`](https://github.com/cachix/git-hooks.nix/commit/cfac92f4f4a9442e2da039b5e95765341b04d8b2) | `` Fix clang-tidy hook always being skipped ``                                               |
| [`8803a39a`](https://github.com/cachix/git-hooks.nix/commit/8803a39afa8b3bfc88b7e3646a07450b57f4e27a) | `` readme: remove flake-utils reference ``                                                   |
| [`de8ccbdc`](https://github.com/cachix/git-hooks.nix/commit/de8ccbdc89a9a344a5821b252f66fb3cb1c9ec39) | `` flake: remove flake-utils dependency ``                                                   |
| [`a741bc6e`](https://github.com/cachix/git-hooks.nix/commit/a741bc6e926abaf9d4dbd65b28a1f0a82d92078b) | `` flake-parts: add enabledPackages to shell ``                                              |
| [`091eaa3a`](https://github.com/cachix/git-hooks.nix/commit/091eaa3a4130a2d447901e4f14a2b0f061fcd90e) | `` Fix and document lacheck hook ``                                                          |
| [`f0dcdc1b`](https://github.com/cachix/git-hooks.nix/commit/f0dcdc1b204360250028d6496e265a73049b0e14) | `` Update modules/hooks.nix ``                                                               |
| [`9052a48b`](https://github.com/cachix/git-hooks.nix/commit/9052a48b2ad895e0cb3d28d874fe1d423566bd54) | `` refactor: move `rec` keyword to minimize formatting impact ``                             |
| [`bf98b7f1`](https://github.com/cachix/git-hooks.nix/commit/bf98b7f1d0983c091376d5191994d29927d51075) | `` feat: add deprecation warning for `rome` hook ``                                          |
| [`f3a2deee`](https://github.com/cachix/git-hooks.nix/commit/f3a2deee819fe462affd678758c969ec4516923e) | `` Remove packageOverrides from the base hook module ``                                      |
| [`c4e3cd4c`](https://github.com/cachix/git-hooks.nix/commit/c4e3cd4ca89d60be6c6e9b7338e9e3442266000b) | `` Add Flake Checker ``                                                                      |
| [`bc5491d5`](https://github.com/cachix/git-hooks.nix/commit/bc5491d571291052763e34dde78155f59f70e0eb) | `` `config` -> `config.settings` ``                                                          |
| [`8f2d990b`](https://github.com/cachix/git-hooks.nix/commit/8f2d990b994d242f53fd725b50ec8ef9a4d8c512) | `` refactor: deprecate `rome` with `mkRenamedOptionModule` ``                                |
| [`d2b7a5b4`](https://github.com/cachix/git-hooks.nix/commit/d2b7a5b4b8e1ecfd12cedd2e4a4de01bd5a7b5aa) | `` fix: alias rome to biome without formatting ``                                            |
| [`ba2d5199`](https://github.com/cachix/git-hooks.nix/commit/ba2d51990f42e4c48e3390d138bb072ac29b5fa9) | `` revert: "fix: alias "rome" to "biome"" ``                                                 |
| [`59d884a4`](https://github.com/cachix/git-hooks.nix/commit/59d884a4487bbf6347223977463b72e1cd3fb08c) | `` fix(alejandra): one `--exclude` flag per file ``                                          |
| [`05c3a4ea`](https://github.com/cachix/git-hooks.nix/commit/05c3a4eaf1ac8f564b8c6aae34912996cd7c551b) | `` fix: alias "rome" to "biome" ``                                                           |
| [`a6538a8d`](https://github.com/cachix/git-hooks.nix/commit/a6538a8d3d4cdde13a5b8d4a11c6db2262703596) | `` feat: create "biome" hook ``                                                              |
| [`00a90e7b`](https://github.com/cachix/git-hooks.nix/commit/00a90e7bbaffeeecc05a1c8ba814d9edeec84701) | `` Add `extraPackages` for `clippy`, `rustfmt`, `dune-fmt` ``                                |
| [`dc1ffda6`](https://github.com/cachix/git-hooks.nix/commit/dc1ffda6986db8c2ef49e361a1dfb0e800f51083) | `` Add `extraPackages` option for packages propagated to `enabledPackages` ``                |
| [`5069220c`](https://github.com/cachix/git-hooks.nix/commit/5069220c7f47ff139c7c1b01b6996684859d838b) | `` Add lacheck hook ``                                                                       |
| [`6c2316d1`](https://github.com/cachix/git-hooks.nix/commit/6c2316d1b2903cecc3692b6b75fdf078e735ebcd) | `` Filter out nulls from enabledPackages ``                                                  |
| [`eb9778d3`](https://github.com/cachix/git-hooks.nix/commit/eb9778d3a17b192708d2c8da2ce0f22be5e465b3) | `` Set the default hook package to null ``                                                   |
| [`9715094e`](https://github.com/cachix/git-hooks.nix/commit/9715094e7af77f3090b11a43fa43c978a3f4d610) | `` Fix reference to renamed option ``                                                        |
| [`649fb51d`](https://github.com/cachix/git-hooks.nix/commit/649fb51def9772b420737dae9cf7289af80f0a8b) | `` add installation test ``                                                                  |
| [`f3bb9549`](https://github.com/cachix/git-hooks.nix/commit/f3bb95498eaaa49a93bacaf196cdb6cf8e872cdf) | `` Fix link to docs ``                                                                       |
| [`8ae5bb63`](https://github.com/cachix/git-hooks.nix/commit/8ae5bb63f9bcd0472b67cf4ada414ae37f1f2bcc) | `` Update hook module import for default hooks ``                                            |
| [`cc709e51`](https://github.com/cachix/git-hooks.nix/commit/cc709e51ce0dfaac452dbacbd4c5a9b40e89c79f) | `` refactor: DRY hookModule and upgrade to option ``                                         |