### PR TITLE
chore(flake/gitignore): `43e1aa13` -> `637db329`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                      |
| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`24564f79`](https://github.com/hercules-ci/gitignore.nix/commit/24564f7919d070c32c740934331f0e0f1ae1f399) | `` nix/ci.nix: Test nixos-23.11 ``           |
| [`71f8c3a2`](https://github.com/hercules-ci/gitignore.nix/commit/71f8c3a2e66302af71352c452b27164cec5d4f5f) | `` ci.nix: Drop nixos-19.03 ``               |
| [`dc93a4d2`](https://github.com/hercules-ci/gitignore.nix/commit/dc93a4d2782b4f73b04bb18641d9f29feb8913da) | `` Add outPath short-circuiting tests ``     |
| [`7a023a99`](https://github.com/hercules-ci/gitignore.nix/commit/7a023a99ca8e37f3114bab4d6298ecc3cef33b9c) | `` Make gitignoreSourceWith short-circuit `` |